### PR TITLE
Add custom documentation support to alias macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Security Checklist section in README.md with best practices.
 - Updated README.md with cross-links to SECURITY.md, improved formatting, and security emphasis.
 - **Dedicated serde fuzz target** (`fuzz_targets/serde.rs`) for secure deserialization testing: covers JSON/TOML/YAML parsing, validation logic, zeroization on invalid inputs, temporary allocation handling, and edge cases to prevent deserialization-based vulnerabilities from untrusted structured data.
+- Optional custom rustdoc string support added to all non-generic alias macros (`fixed_alias!`, `dynamic_alias!`, `fixed_alias_random!`) for full consistency with generic variants. Accepts an optional third parameter for custom documentation, falling back to generated docs when omitted. Backward compatible and improves API discoverability.
 
 ### Changed (Breaking)
 - **Encoding wrappers method renames** (#52): Renamed decode methods to follow Rust stdlib naming conventions:

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -398,10 +398,12 @@ assert_eq!(use_random(&key), 32);
 use secure_gate::fixed_alias;
 
 fixed_alias!(pub Aes256Key, 32);
+fixed_alias!(pub ApiKey, 32, "API key for external service");  // Custom doc
 fixed_alias!(pub(crate) InternalKey, 64);
 fixed_alias!(InternalNonce, 24);  // Private
 
 let key: Aes256Key = [0u8; 32].into();
+let api_key: ApiKey = [0u8; 32].into();
 ```
 
 ### Generic Fixed (Stack) Buffers
@@ -419,10 +421,12 @@ let buffer32 = SecureBuffer::<32>::new([0u8; 32]);
 use secure_gate::dynamic_alias;
 
 dynamic_alias!(pub Password, String);
+dynamic_alias!(pub Token, Vec<u8>, "OAuth access token");  // Custom doc
 dynamic_alias!(pub(crate) Payload, Vec<u8>);
 dynamic_alias!(InternalToken, String);  // Private
 
 let pw: Password = "hunter2".into();
+let token: Token = vec![0u8; 16].into();
 ```
 
 ### Generic Dynamic (Heap)
@@ -443,11 +447,14 @@ use secure_gate::fixed_alias_random;
 #[cfg(feature = "rand")]
 fixed_alias_random!(pub MasterKey, 32);
 #[cfg(feature = "rand")]
+fixed_alias_random!(pub SessionKey, 32, "Random session key for auth");  // Custom doc
+#[cfg(feature = "rand")]
 fixed_alias_random!(pub(crate) SessionNonce, 24);
 #[cfg(feature = "rand")]
 fixed_alias_random!(InternalNonce, 24);  // Private
 
 let master = MasterKey::generate();
+let session = SessionKey::generate();
 ```
 
 ### Exportable (Serializable) Aliases (Requires `serde-serialize`)

--- a/README.md
+++ b/README.md
@@ -392,6 +392,14 @@ fixed_alias!(pub Aes256Key, 32); // Fixed<[u8; 32]>
 dynamic_alias!(pub Password, String); // Dynamic<String>
 ```
 
+With custom documentation:
+
+```rust
+use secure_gate::{fixed_alias, dynamic_alias};
+fixed_alias!(pub ApiKey, 32, "API key for service authentication");
+dynamic_alias!(pub Token, Vec<u8>, "OAuth access token");
+```
+
 ### Generic Aliases
 
 For reusable or library-provided secret types:
@@ -422,6 +430,18 @@ dynamic_generic_alias!(pub SecureHeap, String, "Generic heap-allocated secret");
     fixed_alias_random!(pub MasterKey, 32); // FixedRandom<32>
 }
 ```
+
+With custom documentation:
+
+```rust
+#[cfg(feature = "rand")]
+{
+    use secure_gate::fixed_alias_random;
+
+    fixed_alias_random!(pub SessionKey, 32, "Random session key for authentication");
+}
+```
+
 
 These macros create type aliases to `Fixed<[u8; N]>`, `Dynamic<T>`, `FixedRandom<N>`, or their generic counterparts, inheriting all methods and security guarantees.
 

--- a/src/macros/dynamic.rs
+++ b/src/macros/dynamic.rs
@@ -1,4 +1,9 @@
-/// Creates a type alias for a heap-allocated secure secret.
+/// Creates a type alias for a heap-allocated secure secret with optional custom documentation.
+///
+/// # Syntax
+///
+/// - `dynamic_alias!(vis Name, Type);` — visibility required (e.g., `pub`, `pub(crate)`, or omit for private)
+/// - `dynamic_alias!(vis Name, Type, doc);` — with optional custom doc string
 ///
 /// # Examples
 ///
@@ -16,11 +21,26 @@
 /// dynamic_alias!(SecretString, String); // No visibility modifier = private
 /// let secret = SecretString::new("hidden".to_string());
 /// ```
+///
+/// With custom documentation:
+/// ```
+/// use secure_gate::{dynamic_alias, ExposeSecret};
+/// dynamic_alias!(pub Token, Vec<u8>, "OAuth token for API access");
+/// let token: Token = vec![1, 2, 3].into();
+/// ```
 #[macro_export]
 macro_rules! dynamic_alias {
+    ($vis:vis $name:ident, $inner:ty, $doc:literal) => {
+        #[doc = $doc]
+        $vis type $name = $crate::Dynamic<$inner>;
+    };
     ($vis:vis $name:ident, $inner:ty) => {
         #[doc = concat!("Secure heap-allocated ", stringify!($inner))]
         $vis type $name = $crate::Dynamic<$inner>;
+    };
+    ($name:ident, $inner:ty, $doc:literal) => {
+        #[doc = $doc]
+        type $name = $crate::Dynamic<$inner>;
     };
     ($name:ident, $inner:ty) => {
         #[doc = concat!("Secure heap-allocated ", stringify!($inner))]

--- a/src/macros/fixed.rs
+++ b/src/macros/fixed.rs
@@ -1,11 +1,12 @@
 /// Creates a type alias for a fixed-size secure secret.
 ///
-/// This macro generates a type alias to `Fixed<[u8; N]>` with optional visibility.
+/// This macro generates a type alias to `Fixed<[u8; N]>` with optional visibility and custom documentation.
 /// The generated type inherits all methods from `Fixed`, including `.expose_secret()`.
 ///
 /// # Syntax
 ///
 /// - `fixed_alias!(vis Name, size);` — visibility required (e.g., `pub`, `pub(crate)`, or omit for private)
+/// - `fixed_alias!(vis Name, size, doc);` — with optional custom doc string
 ///
 /// # Examples
 ///
@@ -27,14 +28,30 @@
 /// fixed_alias!(pub(crate) InternalKey, 64); // Crate-visible
 /// ```
 ///
+/// With custom documentation:
+/// ```
+/// use secure_gate::fixed_alias;
+/// fixed_alias!(pub ApiKey, 32, "API key for external service");
+/// ```
+///
 /// The generated type is zero-cost and works with all features.
 /// For random initialization, use Type::generate() (requires 'rand' feature).
 #[macro_export]
 macro_rules! fixed_alias {
+    ($vis:vis $name:ident, $size:literal, $doc:literal) => {
+        #[doc = $doc]
+        const _: () = { let _ = [(); $size][0]; };
+        $vis type $name = $crate::Fixed<[u8; $size]>;
+    };
     ($vis:vis $name:ident, $size:literal) => {
         #[doc = concat!("Fixed-size secure secret (", stringify!($size), " bytes)")]
         const _: () = { let _ = [(); $size][0]; };
         $vis type $name = $crate::Fixed<[u8; $size]>;
+    };
+    ($name:ident, $size:literal, $doc:literal) => {
+        #[doc = $doc]
+        const _: () = { let _ = [(); $size][0]; };
+        type $name = $crate::Fixed<[u8; $size]>;
     };
     ($name:ident, $size:literal) => {
         #[doc = concat!("Fixed-size secure secret (", stringify!($size), " bytes)")]
@@ -98,13 +115,32 @@ macro_rules! fixed_generic_alias {
 /// fixed_alias_random!(PrivateKey, 32); // No visibility modifier = private
 /// # }
 /// ```
+///
+/// With custom documentation:
+/// ```
+/// #[cfg(feature = "rand")]
+/// {
+/// use secure_gate::fixed_alias_random;
+/// fixed_alias_random!(pub SessionKey, 32, "Random session key for authentication");
+/// # }
+/// ```
 /// Instantiate with Type::generate() (requires 'rand' feature).
 #[macro_export]
 macro_rules! fixed_alias_random {
+    ($vis:vis $name:ident, $size:literal, $doc:literal) => {
+        #[doc = $doc]
+        const _: () = { let _ = [(); $size][0]; };
+        $vis type $name = $crate::random::FixedRandom<$size>;
+    };
     ($vis:vis $name:ident, $size:literal) => {
         #[doc = concat!("Random-only fixed-size secret (", stringify!($size), " bytes)")]
         const _: () = { let _ = [(); $size][0]; };
         $vis type $name = $crate::random::FixedRandom<$size>;
+    };
+    ($name:ident, $size:literal, $doc:literal) => {
+        #[doc = $doc]
+        const _: () = { let _ = [(); $size][0]; };
+        type $name = $crate::random::FixedRandom<$size>;
     };
     ($name:ident, $size:literal) => {
         #[doc = concat!("Random-only fixed-size secret (", stringify!($size), " bytes)")]

--- a/tests/macros/dynamic_macros_tests.rs
+++ b/tests/macros/dynamic_macros_tests.rs
@@ -53,3 +53,11 @@ fn root_visibility_works() {
     let _g: GlobalPass = "global".into();
     let _r: RootPrivateToken = vec![0; 10].into();
 }
+
+#[test]
+fn dynamic_alias_with_custom_doc() {
+    dynamic_alias!(pub DynamicWithDoc, String, "Custom documentation for dynamic secret");
+
+    let d: DynamicWithDoc = "secret".into();
+    assert_eq!(d.expose_secret(), "secret");
+}

--- a/tests/macros/fixed_macros_tests.rs
+++ b/tests/macros/fixed_macros_tests.rs
@@ -115,6 +115,23 @@ fn fixed_aliases_distinct_types() {
     // Compile-fail guard: ensures semantic types don't coerce
 }
 
+#[test]
+fn fixed_alias_with_custom_doc() {
+    fixed_alias!(pub KeyWithDoc, 32, "Custom documentation for key");
+
+    let k: KeyWithDoc = [0u8; 32].into();
+    assert_eq!(k.len(), 32);
+}
+
+#[cfg(feature = "rand")]
+#[test]
+fn fixed_alias_random_with_custom_doc() {
+    fixed_alias_random!(pub RngKeyWithDoc, 32, "Custom documentation for random key");
+
+    let k = RngKeyWithDoc::generate();
+    assert_eq!(k.len(), 32);
+}
+
 #[cfg(feature = "rand")]
 #[test]
 fn rng_aliases_distinct_types() {


### PR DESCRIPTION
This change introduces optional custom rustdoc strings to non-generic alias macros (`fixed_alias!`, `dynamic_alias!`, `fixed_alias_random!`) for consistency with generic variants. It updates macro definitions, documentation, examples, and adds corresponding tests.

Closes #60