### PR TITLE
Replace hex/base64 with constant-time RustCrypto backends, enable no-alloc decoding

### DIFF
--- a/secure-gate-core/src/dynamic.rs
+++ b/secure-gate-core/src/dynamic.rs
@@ -541,9 +541,10 @@ impl Dynamic<alloc::vec::Vec<u8>> {
 impl<T: ?Sized + zeroize::Zeroize> crate::ConstantTimeEq for Dynamic<T>
 where
     T: crate::ConstantTimeEq,
+    Self: crate::RevealSecret<Inner = T>,
 {
     fn ct_eq(&self, other: &Self) -> bool {
-        self.inner.ct_eq(&other.inner)
+        self.expose_secret().ct_eq(other.expose_secret())
     }
 }
 

--- a/secure-gate-core/src/fixed.rs
+++ b/secure-gate-core/src/fixed.rs
@@ -675,9 +675,10 @@ impl<const N: usize> Fixed<[u8; N]> {
 impl<T: zeroize::Zeroize> crate::ConstantTimeEq for Fixed<T>
 where
     T: crate::ConstantTimeEq,
+    Self: crate::RevealSecret<Inner = T>,
 {
     fn ct_eq(&self, other: &Self) -> bool {
-        self.inner.ct_eq(&other.inner)
+        self.expose_secret().ct_eq(other.expose_secret())
     }
 }
 

--- a/secure-gate-core/src/lib.rs
+++ b/secure-gate-core/src/lib.rs
@@ -8,7 +8,8 @@
 //! `no_std`-compatible, zero-overhead library with audit-friendly access patterns.
 //!
 //! Secrets are **automatically zeroized on drop** (the inner type must implement [`Zeroize`](zeroize::Zeroize)).
-//! Explicit access only via [`RevealSecret`]/[`RevealSecretMut`] — no `Deref`, no accidental leaks.
+//! No `Deref`, no accidental leaks — callers access the inner secret only via
+//! [`RevealSecret`]/[`RevealSecretMut`].
 //! `Debug` always prints `[REDACTED]`.
 //!
 //! - [`Fixed<T>`] — stack-allocated, compile-time-sized secrets (keys, nonces, tokens)


### PR DESCRIPTION
- Drop hex v0.4 and base64 v0.22; add base16ct v1 and base64ct v1 (RustCrypto)
- All encoding/decoding now uses constant-time backends with no transitive deps
- Fixed::try_from_hex/base64url/bech32/bech32m now work without alloc feature
  - Decode directly into Zeroizing<[u8; N]> stack buffers (no Vec allocation)
  - Blanket trait decoding (FromHexStr, etc.) remain alloc-only (return Vec<u8>)
- Feature gating: encoding traits (ToHex, etc.) now require alloc (return String)
- Regroup encoding+decoding methods by protocol in Fixed/Dynamic impl blocks
- Add EncodedSecret::Display doc note warning against logging with {}
- Add 15 new no-alloc decode path tests; 121 total pass
- All no-alloc builds verified clean (--no-default-features + encoding features)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core secret encoding/decoding and feature-gating; behavior should be output-compatible but errors/length handling and no-alloc paths could affect downstream callers across multiple formats.
> 
> **Overview**
> Replaces `hex`/`base64` dependencies with RustCrypto’s constant-time `base16ct` and `base64ct`, updates encoding/decoding traits and wrapper helpers accordingly, and adjusts feature flags so encoding-to-`String` APIs are `alloc`-gated while `Fixed<[u8; N]>` decoding works without `alloc` via stack `Zeroizing<[u8; N]>` buffers.
> 
> Refactors `Fixed`/`Dynamic<Vec<u8>>` encoding+decoding impl blocks (including explicit HRP-validated Bech32/Bech32m decode paths), tweaks `ct_eq` wrapper implementations to compare via `expose_secret()`, and expands tests/trybuild coverage for no-alloc decoding, wrapper conversions, error source chains, serde limit boundaries, and compat mutable exposure semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e3dd199c500d16fc30cf7a8c35be39268c3f5db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->