### PR TITLE
Claude/analyze test coverage ol ef4

### DIFF
--- a/secure-gate-compat/tests/compat_suite/v10.rs
+++ b/secure-gate-compat/tests/compat_suite/v10.rs
@@ -75,6 +75,34 @@ fn secret_box_expose_secret_mut() {
     assert_eq!(sb.expose_secret(), "original_modified");
 }
 
+// ── 2b. SecretString / SecretSlice expose_secret_mut ─────────────────────────
+
+#[test]
+fn secret_string_expose_secret_mut() {
+    // SecretString = SecretBox<str>, so expose_secret_mut returns &mut str.
+    // &mut str does not support push_str, but we can modify bytes in-place.
+    let mut ss: SecretString = "hello".into();
+    let s: &mut str = ExposeSecretMut::expose_secret_mut(&mut ss);
+    // Verify we get mutable access and can modify individual bytes.
+    unsafe { s.as_bytes_mut()[0] = b'H'; }
+    assert_eq!(ss.expose_secret(), "Hello");
+}
+
+#[test]
+fn secret_slice_expose_secret_mut_modify() {
+    // SecretSlice<u8> = SecretBox<[u8]>, so expose_secret_mut returns &mut [u8].
+    let mut sl: SecretSlice<u8> = vec![10u8, 20, 30].into();
+    ExposeSecretMut::expose_secret_mut(&mut sl)[0] = 99;
+    assert_eq!(sl.expose_secret()[0], 99);
+}
+
+#[test]
+fn secret_slice_expose_secret_mut_fill() {
+    let mut sl: SecretSlice<u8> = vec![0u8; 4].into();
+    ExposeSecretMut::expose_secret_mut(&mut sl).fill(0xFF);
+    assert_eq!(sl.expose_secret(), &[0xFFu8; 4]);
+}
+
 // ── 3. SecretString ───────────────────────────────────────────────────────────
 
 #[test]

--- a/secure-gate-core/src/dynamic.rs
+++ b/secure-gate-core/src/dynamic.rs
@@ -541,9 +541,10 @@ impl Dynamic<alloc::vec::Vec<u8>> {
 impl<T: ?Sized + zeroize::Zeroize> crate::ConstantTimeEq for Dynamic<T>
 where
     T: crate::ConstantTimeEq,
+    Self: crate::RevealSecret<Inner = T>,
 {
     fn ct_eq(&self, other: &Self) -> bool {
-        self.inner.ct_eq(&other.inner)
+        self.expose_secret().ct_eq(other.expose_secret())
     }
 }
 

--- a/secure-gate-core/src/fixed.rs
+++ b/secure-gate-core/src/fixed.rs
@@ -675,9 +675,10 @@ impl<const N: usize> Fixed<[u8; N]> {
 impl<T: zeroize::Zeroize> crate::ConstantTimeEq for Fixed<T>
 where
     T: crate::ConstantTimeEq,
+    Self: crate::RevealSecret<Inner = T>,
 {
     fn ct_eq(&self, other: &Self) -> bool {
-        self.inner.ct_eq(&other.inner)
+        self.expose_secret().ct_eq(other.expose_secret())
     }
 }
 

--- a/secure-gate-core/src/lib.rs
+++ b/secure-gate-core/src/lib.rs
@@ -8,7 +8,8 @@
 //! `no_std`-compatible, zero-overhead library with audit-friendly access patterns.
 //!
 //! Secrets are **automatically zeroized on drop** (the inner type must implement [`Zeroize`](zeroize::Zeroize)).
-//! Explicit access only via [`RevealSecret`]/[`RevealSecretMut`] — no `Deref`, no accidental leaks.
+//! No `Deref`, no accidental leaks — callers access the inner secret only via
+//! [`RevealSecret`]/[`RevealSecretMut`].
 //! `Debug` always prints `[REDACTED]`.
 //!
 //! - [`Fixed<T>`] — stack-allocated, compile-time-sized secrets (keys, nonces, tokens)

--- a/secure-gate-core/tests/compile-fail/dynamic_string_no_hex.rs
+++ b/secure-gate-core/tests/compile-fail/dynamic_string_no_hex.rs
@@ -1,0 +1,7 @@
+use secure_gate::Dynamic;
+
+fn main() {
+    let secret: Dynamic<String> = Dynamic::new(String::from("not_bytes"));
+    // Dynamic<String> must NOT have encoding methods — only Dynamic<Vec<u8>> does.
+    let _ = secret.to_hex();
+}

--- a/secure-gate-core/tests/compile-fail/dynamic_string_no_hex.stderr
+++ b/secure-gate-core/tests/compile-fail/dynamic_string_no_hex.stderr
@@ -1,0 +1,8 @@
+error[E0599]: no method named `to_hex` found for struct `Dynamic<String>` in the current scope
+ --> tests/compile-fail/dynamic_string_no_hex.rs:6:20
+  |
+6 |     let _ = secret.to_hex();
+  |                    ^^^^^^ method not found in `Dynamic<String>`
+  |
+  = note: the method was found for
+          - `Dynamic<Vec<u8>>`

--- a/secure-gate-core/tests/compile_fail_tests.rs
+++ b/secure-gate-core/tests/compile_fail_tests.rs
@@ -23,3 +23,13 @@ fn serializable_secret_misuse() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/compile-fail/serializable_secret_misuse.rs");
 }
+
+// Compile-fail test: Dynamic<String> must not expose encoding methods (hex, base64, etc.)
+// These methods are intentionally defined only on Dynamic<Vec<u8>>.
+#[cfg(all(feature = "alloc", feature = "encoding-hex"))]
+#[cfg(not(miri))]
+#[test]
+fn dynamic_string_no_hex_compile_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/dynamic_string_no_hex.rs");
+}

--- a/secure-gate-core/tests/core_tests.rs
+++ b/secure-gate-core/tests/core_tests.rs
@@ -114,6 +114,40 @@ fn dynamic_vec_from_slice() {
     dyn_vec.with_secret(|s| assert_eq!(s, b"hello world"));
 }
 
+// === Dynamic<T> From impls ===
+
+#[cfg(feature = "alloc")]
+#[test]
+fn dynamic_from_box_vec() {
+    let boxed: Box<Vec<u8>> = Box::new(vec![1u8, 2, 3]);
+    let d: Dynamic<Vec<u8>> = boxed.into();
+    d.with_secret(|s| assert_eq!(s, &[1u8, 2, 3]));
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn dynamic_from_box_string() {
+    let boxed: Box<String> = Box::new(String::from("boxed_secret"));
+    let d: Dynamic<String> = boxed.into();
+    d.with_secret(|s| assert_eq!(s, "boxed_secret"));
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn dynamic_from_owned_vec() {
+    let v = vec![10u8, 20, 30];
+    let d: Dynamic<Vec<u8>> = v.into();
+    d.with_secret(|s| assert_eq!(s, &[10u8, 20, 30]));
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn dynamic_from_owned_string() {
+    let s = String::from("owned_secret");
+    let d: Dynamic<String> = s.into();
+    d.with_secret(|s| assert_eq!(s, "owned_secret"));
+}
+
 // === TryFrom for Fixed ===
 #[test]
 fn fixed_try_from_slice() {

--- a/secure-gate-core/tests/ct_eq_tests.rs
+++ b/secure-gate-core/tests/ct_eq_tests.rs
@@ -39,6 +39,30 @@ fn wrapper_ct_eq_dynamic_and_fixed() {
     assert!(!dyn1.ct_eq(&dyn3));
 }
 
+#[cfg(all(feature = "ct-eq", feature = "alloc"))]
+#[test]
+fn string_ct_eq_basic() {
+    let a = String::from("hello");
+    let b = String::from("hello");
+    let c = String::from("world");
+    let d = String::from("hel");
+    assert!(a.ct_eq(&b));
+    assert!(!a.ct_eq(&c));
+    assert!(!a.ct_eq(&d));
+}
+
+#[cfg(all(feature = "ct-eq", feature = "alloc"))]
+#[test]
+fn wrapper_ct_eq_dynamic_string() {
+    let d1: Dynamic<String> = "secret".into();
+    let d2: Dynamic<String> = "secret".into();
+    let d3: Dynamic<String> = "differ".into();
+    let d4: Dynamic<String> = "short".into();
+    assert!(d1.ct_eq(&d2));
+    assert!(!d1.ct_eq(&d3));
+    assert!(!d1.ct_eq(&d4));
+}
+
 #[cfg(all(not(feature = "ct-eq"), feature = "alloc"))]
 #[test]
 fn manual_comparison_without_ct_eq_feature() {

--- a/secure-gate-core/tests/error_tests.rs
+++ b/secure-gate-core/tests/error_tests.rs
@@ -152,6 +152,38 @@ fn bech32_error_invalid_length_cfg() {
     }
 }
 
+/// Test DecodingError #[source] chain — verifies the thiserror source() method
+/// returns the inner error for each feature-gated variant.
+#[cfg(feature = "encoding-hex")]
+#[test]
+fn decoding_error_source_hex() {
+    use std::error::Error;
+    let inner = secure_gate::HexError::InvalidHex;
+    let outer = DecodingError::InvalidHex(inner.clone());
+    let source = outer.source().expect("DecodingError::InvalidHex must have a source");
+    assert!(source.to_string().contains("invalid hex"));
+}
+
+#[cfg(feature = "encoding-base64")]
+#[test]
+fn decoding_error_source_base64() {
+    use std::error::Error;
+    let inner = secure_gate::Base64Error::InvalidBase64;
+    let outer = DecodingError::InvalidBase64(inner.clone());
+    let source = outer.source().expect("DecodingError::InvalidBase64 must have a source");
+    assert!(source.to_string().contains("invalid base64"));
+}
+
+#[cfg(feature = "encoding-bech32")]
+#[test]
+fn decoding_error_source_bech32() {
+    use std::error::Error;
+    let inner = Bech32Error::OperationFailed;
+    let outer = DecodingError::InvalidBech32(inner.clone());
+    let source = outer.source().expect("DecodingError::InvalidBech32 must have a source");
+    assert!(source.to_string().contains("bech32 operation failed"));
+}
+
 /// Test Bech32Error UnexpectedHrp cfg-split
 #[cfg(feature = "encoding-bech32")]
 #[test]

--- a/secure-gate-core/tests/serde_suite/deserialize.rs
+++ b/secure-gate-core/tests/serde_suite/deserialize.rs
@@ -95,3 +95,52 @@ fn dynamic_string_deserialize_with_limit_rejects_over_limit() {
     let result = Dynamic::<String>::deserialize_with_limit(&mut de, 4);
     assert!(result.is_err());
 }
+
+// ---------------------------------------------------------------------------
+// deserialize_with_limit — boundary conditions
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "serde-deserialize")]
+#[test]
+fn dynamic_vec_deserialize_with_limit_zero_accepts_empty() {
+    use secure_gate::{Dynamic, RevealSecret};
+    let mut de = serde_json::Deserializer::from_str("[]");
+    let result = Dynamic::<Vec<u8>>::deserialize_with_limit(&mut de, 0).expect("empty within limit 0");
+    assert!(result.expose_secret().is_empty());
+}
+
+#[cfg(feature = "serde-deserialize")]
+#[test]
+fn dynamic_vec_deserialize_with_limit_zero_rejects_nonempty() {
+    use secure_gate::Dynamic;
+    let mut de = serde_json::Deserializer::from_str("[1]");
+    let result = Dynamic::<Vec<u8>>::deserialize_with_limit(&mut de, 0);
+    assert!(result.is_err());
+}
+
+#[cfg(feature = "serde-deserialize")]
+#[test]
+fn dynamic_string_deserialize_with_limit_zero_accepts_empty() {
+    use secure_gate::{Dynamic, RevealSecret};
+    let mut de = serde_json::Deserializer::from_str("\"\"");
+    let result = Dynamic::<String>::deserialize_with_limit(&mut de, 0).expect("empty within limit 0");
+    assert!(result.expose_secret().is_empty());
+}
+
+#[cfg(feature = "serde-deserialize")]
+#[test]
+fn dynamic_string_deserialize_with_limit_zero_rejects_nonempty() {
+    use secure_gate::Dynamic;
+    let mut de = serde_json::Deserializer::from_str("\"a\"");
+    let result = Dynamic::<String>::deserialize_with_limit(&mut de, 0);
+    assert!(result.is_err());
+}
+
+#[cfg(feature = "serde-deserialize")]
+#[test]
+fn dynamic_vec_deserialize_with_limit_one() {
+    use secure_gate::{Dynamic, RevealSecret};
+    let mut de = serde_json::Deserializer::from_str("[42]");
+    let result = Dynamic::<Vec<u8>>::deserialize_with_limit(&mut de, 1).expect("single element within limit 1");
+    assert_eq!(result.expose_secret(), &[42u8]);
+}

--- a/secure-gate-core/tests/serde_suite/roundtrip.rs
+++ b/secure-gate-core/tests/serde_suite/roundtrip.rs
@@ -107,3 +107,65 @@ fn dynamic_wrapper_serializes_correctly() {
     let raw: Vec<u8> = serde_json::from_str(&json).expect("parse JSON");
     assert_eq!(raw, [5, 6, 7, 8]);
 }
+
+// ---------------------------------------------------------------------------
+// Full wrapper round-trips: serialize Fixed/Dynamic → JSON → deserialize back
+// ---------------------------------------------------------------------------
+
+/// Fixed<[u8; N]> serde round-trip: serialize the raw array, deserialize into
+/// the Fixed wrapper, then verify inner data matches. This exercises the
+/// FixedVisitor deserialization path with known data.
+#[cfg(all(feature = "serde-deserialize", feature = "serde-serialize"))]
+#[test]
+fn fixed_wrapper_serde_roundtrip() {
+    use secure_gate::{Fixed, RevealSecret};
+
+    let data = [0xAAu8, 0xBB, 0xCC, 0xDD];
+    let json = serde_json::to_string(&data).expect("serialize raw array");
+    let restored: Fixed<[u8; 4]> = serde_json::from_str(&json).expect("deserialize Fixed<[u8; 4]>");
+    assert_eq!(restored.expose_secret(), &data);
+}
+
+/// Dynamic<Vec<u8>> serde round-trip: serialize the raw Vec, deserialize into
+/// the Dynamic wrapper, then verify inner data matches.
+#[cfg(all(feature = "serde-deserialize", feature = "serde-serialize", feature = "alloc"))]
+#[test]
+fn dynamic_vec_wrapper_serde_roundtrip() {
+    use secure_gate::{Dynamic, RevealSecret};
+
+    let data = vec![1u8, 2, 3, 4, 5];
+    let json = serde_json::to_string(&data).expect("serialize raw Vec");
+    let restored: Dynamic<Vec<u8>> = serde_json::from_str(&json).expect("deserialize Dynamic<Vec<u8>>");
+    assert_eq!(restored.expose_secret().as_slice(), data.as_slice());
+}
+
+/// Dynamic<String> serde round-trip: serialize the raw String, deserialize into
+/// the Dynamic wrapper, then verify inner data matches.
+#[cfg(all(feature = "serde-deserialize", feature = "serde-serialize", feature = "alloc"))]
+#[test]
+fn dynamic_string_wrapper_serde_roundtrip() {
+    use secure_gate::{Dynamic, RevealSecret};
+
+    let data = String::from("round_trip_secret");
+    let json = serde_json::to_string(&data).expect("serialize raw String");
+    let restored: Dynamic<String> = serde_json::from_str(&json).expect("deserialize Dynamic<String>");
+    assert_eq!(restored.expose_secret().as_str(), data.as_str());
+}
+
+/// Full wrapper-to-wrapper round-trip for a custom SerializableSecret type.
+/// Serializes Fixed<SecretKey> → JSON → deserializes back (as raw) → verifies.
+#[cfg(all(feature = "serde-deserialize", feature = "serde-serialize"))]
+#[test]
+fn fixed_custom_type_serialize_then_deserialize_raw() {
+    use secure_gate::{Fixed, RevealSecret};
+
+    #[derive(serde::Serialize, serde::Deserialize, zeroize::Zeroize)]
+    struct Key([u8; 4]);
+    impl SerializableSecret for Key {}
+
+    let secret = Fixed::new(Key([0x10, 0x20, 0x30, 0x40]));
+    let json = serde_json::to_string(&secret).expect("serialize Fixed<Key>");
+    // The serialized form is the inner array — deserialize as Fixed<[u8; 4]>.
+    let restored: Fixed<[u8; 4]> = serde_json::from_str(&json).expect("deserialize Fixed<[u8; 4]>");
+    assert_eq!(restored.expose_secret(), &[0x10, 0x20, 0x30, 0x40]);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Small but security-adjacent change to `ct_eq` on `Dynamic`/`Fixed` could affect constant-time comparison behavior across wrapper types. The rest is primarily additional test coverage (including compile-fail assertions) with low runtime risk.
> 
> **Overview**
> Expands test coverage across `secure-gate-core` and `secure-gate-compat`, including mutable exposure for `SecretString`/`SecretSlice`, additional `Dynamic<T>` conversion cases, constant-time equality for `String`/`Dynamic<String>`, richer serde `deserialize_with_limit` boundary tests, and end-to-end serde roundtrip tests for `Fixed`/`Dynamic` wrappers.
> 
> Tightens API guarantees via a new trybuild compile-fail test ensuring `Dynamic<String>` does **not** expose byte-encoding helpers like `to_hex`, and adds error-chain tests verifying `DecodingError` variants correctly expose their `source()`.
> 
> Updates `ct-eq` wrapper implementations for `Dynamic<T>` and `Fixed<T>` to perform comparisons through `RevealSecret::expose_secret()` (with an added `RevealSecret` bound) rather than accessing `inner` directly, plus a small crate-level doc wording tweak.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4a386149c62a62013fb5455fe19ff87cd4cdf92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->