### PR TITLE
fix(ci): add --manifest-path to cargo fuzz commands in fuzz-nightly.yml

### DIFF
--- a/.github/workflows/fuzz-nightly-lts.yml
+++ b/.github/workflows/fuzz-nightly-lts.yml
@@ -58,21 +58,21 @@ jobs:
         continue-on-error: true
         with:
           pattern: fuzz-corpus-lts-*
-          path: fuzz/corpus-downloaded/
+          path: secure-gate-core/fuzz/corpus-downloaded/
           merge-multiple: true
 
       - name: Populate per-target corpus directories
         run: |
-          mkdir -p fuzz/corpus
+          mkdir -p secure-gate-core/fuzz/corpus
           for t in expose mut parsing encoding serde ct_eq; do
-            mkdir -p "fuzz/corpus/$t"
-            find fuzz/corpus-downloaded -type f -name "*$t*" -exec cp {} "fuzz/corpus/$t/" \; 2>/dev/null || true
+            mkdir -p "secure-gate-core/fuzz/corpus/$t"
+            find secure-gate-core/fuzz/corpus-downloaded -type f -name "*$t*" -exec cp {} "secure-gate-core/fuzz/corpus/$t/" \; 2>/dev/null || true
           done
 
       - name: Seed minimal corpus (first-run safety net)
         run: |
           for t in expose mut parsing encoding serde ct_eq; do
-            dir="fuzz/corpus/$t"
+            dir="secure-gate-core/fuzz/corpus/$t"
             if [ ! -d "$dir" ] || [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
               mkdir -p "$dir"
               printf 'fuzzme' > "$dir/seed_basic"
@@ -83,7 +83,7 @@ jobs:
           done
 
           # JSON-specific seeds for serde target
-          dir="fuzz/corpus/serde"
+          dir="secure-gate-core/fuzz/corpus/serde"
           if [ -d "$dir" ]; then
             printf '[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]' > "$dir/seed_fixed32"
             printf '"hello world"' > "$dir/seed_string"
@@ -95,7 +95,7 @@ jobs:
           fi
 
           # Encoding-specific seeds
-          dir="fuzz/corpus/encoding"
+          dir="secure-gate-core/fuzz/corpus/encoding"
           if [ -d "$dir" ]; then
             printf 'deadbeef' > "$dir/seed_hex"
             printf 'DEADBEEF' > "$dir/seed_hex_upper"
@@ -115,8 +115,9 @@ jobs:
             print_stats=1
         run: |
           echo "Fuzzing ${{ matrix.target }} (${{ matrix.mode }}) for ≈58 minutes…"
-          cargo +nightly fuzz run ${{ matrix.target }} \
-            fuzz/corpus/${{ matrix.target }} \
+          cargo +nightly fuzz run --manifest-path secure-gate-core/fuzz/Cargo.toml \
+            ${{ matrix.target }} \
+            secure-gate-core/fuzz/corpus/${{ matrix.target }} \
             -- \
             ${{ env.FUZZER_ARGS }}
 
@@ -125,7 +126,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fuzz-corpus-lts-${{ matrix.target }}-${{ matrix.mode }}-${{ github.run_id }}
-          path: fuzz/corpus/${{ matrix.target }}/
+          path: secure-gate-core/fuzz/corpus/${{ matrix.target }}/
           retention-days: 90
           if-no-files-found: error
 
@@ -134,7 +135,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fuzz-crash-lts-${{ matrix.target }}-${{ matrix.mode }}-${{ github.run_id }}
-          path: fuzz/artifacts/${{ matrix.target }}/**
+          path: secure-gate-core/fuzz/artifacts/${{ matrix.target }}/**
           retention-days: 30
           if-no-files-found: warn
 
@@ -163,21 +164,21 @@ jobs:
         run: cargo install cargo-fuzz --locked
 
       - name: Build fuzz targets in release mode
-        run: cargo +nightly fuzz build --release
+        run: cargo +nightly fuzz build --manifest-path secure-gate-core/fuzz/Cargo.toml --release
 
       - name: Download all fresh corpora
         uses: actions/download-artifact@v4
         with:
           pattern: fuzz-corpus-lts-*
-          path: fuzz/corpus-downloaded/
+          path: secure-gate-core/fuzz/corpus-downloaded/
           merge-multiple: true
 
       - name: Reconstruct corpus directories
         run: |
-          mkdir -p fuzz/corpus
+          mkdir -p secure-gate-core/fuzz/corpus
           for t in expose mut parsing encoding serde ct_eq; do
-            mkdir -p "fuzz/corpus/$t"
-            find fuzz/corpus-downloaded -type f -name "*$t*" -exec cp {} "fuzz/corpus/$t/" \; 2>/dev/null || true
+            mkdir -p "secure-gate-core/fuzz/corpus/$t"
+            find secure-gate-core/fuzz/corpus-downloaded -type f -name "*$t*" -exec cp {} "secure-gate-core/fuzz/corpus/$t/" \; 2>/dev/null || true
           done
 
       - name: Generate HTML + lcov coverage reports
@@ -186,23 +187,25 @@ jobs:
 
           for target in expose mut parsing encoding serde ct_eq; do
             echo "=== Generating coverage for $target ==="
-            corpus="fuzz/corpus/$target"
+            corpus="secure-gate-core/fuzz/corpus/$target"
             [ ! -d "$corpus" ] || [ -z "$(ls -A "$corpus")" ] && continue
 
-            binary=$(find fuzz/target -type f -name "$target" -perm /a=x -print -quit)
+            binary=$(find secure-gate-core/fuzz/target -type f -name "$target" -perm /a=x -print -quit)
             [ -z "$binary" ] && { echo "Binary not found for $target"; continue; }
 
-            cargo +nightly fuzz coverage "$target" "$corpus" -- -runs=300000
+            cargo +nightly fuzz coverage --manifest-path secure-gate-core/fuzz/Cargo.toml \
+              "$target" "$corpus" -- -runs=300000
 
             llvm-cov show \
-              --instr-profile="fuzz/coverage/$target/coverage.profdata" \
+              --instr-profile="secure-gate-core/fuzz/coverage/$target/coverage.profdata" \
               --object="$binary" \
               --format=html \
               --ignore-filename-regex='/.cargo|/rustc/|.*/libfuzzer_sys/' \
               --output-dir="coverage/html/$target" \
               || true
 
-            cargo +nightly fuzz coverage "$target" "$corpus" --lcov --output-path="coverage/lcov/$target.info" || true
+            cargo +nightly fuzz coverage --manifest-path secure-gate-core/fuzz/Cargo.toml \
+              "$target" "$corpus" --lcov --output-path="coverage/lcov/$target.info" || true
           done
 
       - name: Upload HTML coverage report

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -123,7 +123,8 @@ jobs:
             print_stats=1
         run: |
           echo "Fuzzing ${{ matrix.target }} (${{ matrix.mode }}) for ≈58 minutes…"
-          cargo +nightly fuzz run ${{ matrix.target }} \
+          cargo +nightly fuzz run --manifest-path secure-gate-core/fuzz/Cargo.toml \
+            ${{ matrix.target }} \
             secure-gate-core/fuzz/corpus/${{ matrix.target }} \
             -- \
             ${{ env.FUZZER_ARGS }}
@@ -192,23 +193,25 @@ jobs:
 
           for target in expose mut parsing encoding serde ct_eq; do
             echo "=== Generating coverage for $target ==="
-            corpus="fuzz/corpus/$target"
+            corpus="secure-gate-core/fuzz/corpus/$target"
             [ ! -d "$corpus" ] || [ -z "$(ls -A "$corpus")" ] && continue
 
-            binary=$(find fuzz/target -type f -name "$target" -perm /a=x -print -quit)
+            binary=$(find secure-gate-core/fuzz/target -type f -name "$target" -perm /a=x -print -quit)
             [ -z "$binary" ] && { echo "Binary not found for $target"; continue; }
 
-            cargo +nightly fuzz coverage "$target" "$corpus" -- -runs=300000
+            cargo +nightly fuzz coverage --manifest-path secure-gate-core/fuzz/Cargo.toml \
+              "$target" "$corpus" -- -runs=300000
 
             llvm-cov show \
-              --instr-profile="fuzz/coverage/$target/coverage.profdata" \
+              --instr-profile="secure-gate-core/fuzz/coverage/$target/coverage.profdata" \
               --object="$binary" \
               --format=html \
               --ignore-filename-regex='/.cargo|/rustc/|.*/libfuzzer_sys/' \
               --output-dir="coverage/html/$target" \
               || true
 
-            cargo +nightly fuzz coverage "$target" "$corpus" --lcov --output-path="coverage/lcov/$target.info" || true
+            cargo +nightly fuzz coverage --manifest-path secure-gate-core/fuzz/Cargo.toml \
+              "$target" "$corpus" --lcov --output-path="coverage/lcov/$target.info" || true
           done
 
       - name: Upload HTML coverage report


### PR DESCRIPTION
cargo-fuzz looks for fuzz/Cargo.toml relative to the workspace root,
but the manifest lives at secure-gate-core/fuzz/Cargo.toml. All cargo
fuzz invocations (run and coverage) and the path references in the
coverage report step were missing the correct prefix.

https://claude.ai/code/session_01BgDo6bwwXerzJ4az5YPj1t

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that updates paths and `cargo fuzz` invocations; main risk is misconfigured workflow paths causing nightly fuzz/coverage jobs to fail or upload artifacts to the wrong location.
> 
> **Overview**
> Fixes the nightly fuzz GitHub Actions workflows to run against the actual fuzz crate location under `secure-gate-core/`.
> 
> Updates `cargo +nightly fuzz run/build/coverage` to pass `--manifest-path secure-gate-core/fuzz/Cargo.toml` and adjusts corpus/artifact/coverage path references (including coverage binary/profdata lookup) to use `secure-gate-core/fuzz/...`, so corpora downloads/uploads and coverage reports operate on the correct directories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a7f3d97ad49fc6ef59365f9bbf9796e300948ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->