### PR TITLE
ci: fix workflow trigger branch for release/0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "secure-gate"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "secure-gate-compat"
-version = "0.8.0-rc.7"
+version = "0.8.0-rc.8"
 dependencies = [
  "proptest",
  "secrecy 0.10.1",


### PR DESCRIPTION
Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it reshapes CI triggers/matrices and lowers MSRV to 1.70 while converting the repo to a workspace, which can break builds or publishing if any assumptions were missed.
> 
> **Overview**
> This PR retargets GitHub Actions to the `release/0.8` branch and narrows execution via `paths` filters, while expanding CI with a new multi-package lint matrix and adjusting test runs (notably adding `alloc` to encoding feature configs and skipping trybuild compile-fail cases on stable/MSRV).
> 
> It updates fuzz/Miri and ASan jobs to the new workspace layout (`secure-gate-core`/`secure-gate-compat`), and removes the long-running nightly fuzz workflow.
> 
> Repo-wide metadata is reorganized for the workspace: root `Cargo.toml` becomes a `[workspace]` with shared package fields, MSRV is lowered to `1.70`, versions are bumped to `0.8.0-rc.8`, and `Cargo.lock` is regenerated accordingly. Minor housekeeping adds `.editorconfig`/`.gitattributes`, updates `.gitignore`, and rewrites top-level `README.md`/`CHANGELOG.md` to be workspace-oriented.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62fbae0038a8fec30354e137a10f86ac583fbd0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->