### PR TITLE
docs: post-audit polish + refresh stale Cargo.lock (v0.9 / main)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "secure-gate"
-version = "0.9.0-rc.6-dev"
+version = "0.9.0"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "secure-gate-compat"
-version = "0.9.0-rc.6-dev"
+version = "0.9.0"
 dependencies = [
  "proptest",
  "secrecy 0.10.1",

--- a/secure-gate-core/src/macros/fixed_alias.rs
+++ b/secure-gate-core/src/macros/fixed_alias.rs
@@ -72,23 +72,23 @@
 #[macro_export]
 macro_rules! fixed_alias {
     ($vis:vis $name:ident, $size:literal, $doc:literal) => {
-        #[doc = $doc]
         const _: () = { let _ = [(); $size][0]; };
+        #[doc = $doc]
         $vis type $name = $crate::Fixed<[u8; $size]>;
     };
     ($vis:vis $name:ident, $size:literal) => {
-        #[doc = concat!("Fixed-size secure secret (", stringify!($size), " bytes)")]
         const _: () = { let _ = [(); $size][0]; };
+        #[doc = concat!("Fixed-size secure secret (", stringify!($size), " bytes)")]
         $vis type $name = $crate::Fixed<[u8; $size]>;
     };
     ($name:ident, $size:literal, $doc:literal) => {
-        #[doc = $doc]
         const _: () = { let _ = [(); $size][0]; };
+        #[doc = $doc]
         type $name = $crate::Fixed<[u8; $size]>;
     };
     ($name:ident, $size:literal) => {
-        #[doc = concat!("Fixed-size secure secret (", stringify!($size), " bytes)")]
         const _: () = { let _ = [(); $size][0]; };
+        #[doc = concat!("Fixed-size secure secret (", stringify!($size), " bytes)")]
         type $name = $crate::Fixed<[u8; $size]>;
     };
 }

--- a/secure-gate-core/src/traits/constant_time_eq.rs
+++ b/secure-gate-core/src/traits/constant_time_eq.rs
@@ -53,6 +53,15 @@
 //! - `Vec<u8>` / `String` (when `alloc` feature is enabled)
 //!
 //! These cover the most common secret types in cryptographic applications.
+//!
+//! # Length is not constant-time
+//!
+//! For variable-length inputs (`[u8]`, `Vec<u8>`, `String`) the underlying `subtle`
+//! impl returns `false` immediately when lengths differ — only the equal-length
+//! comparison is constant-time. Length is generally not secret in real-world use
+//! (key sizes, MAC sizes, and signature sizes are public protocol parameters), so
+//! this is acceptable. **If length itself is sensitive in your threat model, use a
+//! fixed-size type (`[u8; N]` / `Fixed<[u8; N]>`).**
 
 /// Constant-time equality comparison, preventing timing side-channel attacks.
 ///

--- a/secure-gate-core/src/traits/decoding/base64_url.rs
+++ b/secure-gate-core/src/traits/decoding/base64_url.rs
@@ -46,9 +46,16 @@ use crate::error::Base64Error;
 /// allocation. For no-alloc targets, use `Fixed::try_from_base64url` instead, which
 /// decodes directly into a stack-allocated `[u8; N]` buffer.
 ///
-/// Uses the RFC 4648 URL-safe alphabet without `=` padding. Treat all input as
-/// untrusted; validate lengths and content upstream before wrapping decoded bytes
-/// in secrets.
+/// Uses the RFC 4648 URL-safe alphabet without `=` padding.
+///
+/// **The returned `Vec<u8>` is plain heap memory and is not zeroized on drop.** Wrap
+/// the result in [`Fixed`](crate::Fixed) or [`Dynamic`](crate::Dynamic) immediately
+/// (or in [`zeroize::Zeroizing`]) if the decoded bytes are sensitive. Prefer
+/// `Fixed::try_from_base64url` / `Dynamic::try_from_base64url`, which perform the
+/// wrapping for you and zeroize their internal temporaries.
+///
+/// Treat all input as untrusted; validate lengths and content upstream before wrapping
+/// decoded bytes in secrets.
 #[cfg(all(feature = "encoding-base64", feature = "alloc"))]
 pub trait FromBase64UrlStr {
     /// Decodes a URL-safe base64 string (no padding) into a byte vector.

--- a/secure-gate-core/src/traits/decoding/bech32.rs
+++ b/secure-gate-core/src/traits/decoding/bech32.rs
@@ -58,6 +58,12 @@ use crate::error::Bech32Error;
 /// values, ~5 KB (5,115 bytes maximum payload)) — significantly larger than Bech32m's standard 90-byte
 /// limit. Strings encoded via [`ToBech32`](crate::ToBech32) round-trip correctly here
 /// but will fail with [`FromBech32mStr`](crate::FromBech32mStr) when they exceed ~90 bytes.
+///
+/// **The returned `Vec<u8>` is plain heap memory and is not zeroized on drop.** Wrap
+/// the result in [`Fixed`](crate::Fixed) or [`Dynamic`](crate::Dynamic) immediately
+/// (or in [`zeroize::Zeroizing`]) if the decoded bytes are sensitive. Prefer
+/// `Fixed::try_from_bech32` / `Dynamic::try_from_bech32`, which perform the wrapping
+/// for you and zeroize their internal temporaries.
 #[cfg(feature = "encoding-bech32")]
 pub trait FromBech32Str {
     /// Decodes a Bech32 (BIP-173) string, validating that the HRP matches `expected_hrp`.

--- a/secure-gate-core/src/traits/decoding/bech32m.rs
+++ b/secure-gate-core/src/traits/decoding/bech32m.rs
@@ -61,6 +61,12 @@ use crate::error::Bech32Error;
 /// Bech32m strings (Bitcoin Taproot/SegWit v1+ compatible). The `Bech32Large`
 /// variant used by [`ToBech32`](crate::ToBech32) is a distinct non-standard format
 /// for large payloads; decode those with [`FromBech32Str`](crate::FromBech32Str).
+///
+/// **The returned `Vec<u8>` is plain heap memory and is not zeroized on drop.** Wrap
+/// the result in [`Fixed`](crate::Fixed) or [`Dynamic`](crate::Dynamic) immediately
+/// (or in [`zeroize::Zeroizing`]) if the decoded bytes are sensitive. Prefer
+/// `Fixed::try_from_bech32m` / `Dynamic::try_from_bech32m`, which perform the
+/// wrapping for you and zeroize their internal temporaries.
 #[cfg(feature = "encoding-bech32m")]
 pub trait FromBech32mStr {
     /// Decodes a Bech32m (BIP-350) string, validating that the HRP matches `expected_hrp`.

--- a/secure-gate-core/src/traits/decoding/hex.rs
+++ b/secure-gate-core/src/traits/decoding/hex.rs
@@ -44,6 +44,12 @@ use crate::error::HexError;
 /// allocation. For no-alloc targets, use `Fixed::try_from_hex` instead, which decodes
 /// directly into a stack-allocated `[u8; N]` buffer.
 ///
+/// **The returned `Vec<u8>` is plain heap memory and is not zeroized on drop.** Wrap
+/// the result in [`Fixed`](crate::Fixed) or [`Dynamic`](crate::Dynamic) immediately
+/// (or in [`zeroize::Zeroizing`]) if the decoded bytes are sensitive. Prefer
+/// `Fixed::try_from_hex` / `Dynamic::try_from_hex`, which perform the wrapping for
+/// you and zeroize their internal temporaries.
+///
 /// Treat all input as untrusted; validate lengths and content upstream before wrapping
 /// decoded bytes in secrets.
 #[cfg(all(feature = "encoding-hex", feature = "alloc"))]

--- a/secure-gate-core/src/traits/reveal_secret.rs
+++ b/secure-gate-core/src/traits/reveal_secret.rs
@@ -224,6 +224,15 @@ pub trait RevealSecret {
     /// The returned [`InnerSecret<T>`] always redacts `Debug` as `[REDACTED]`, preserving
     /// the wrapper-level redaction invariant after ownership transfer.
     ///
+    /// # Allocation Behavior
+    ///
+    /// `Fixed::into_inner` is zero-cost (no allocation). The `Dynamic::into_inner`
+    /// impls allocate one small `Box<T>` sentinel (24 bytes on 64-bit) before swapping
+    /// out the real secret; if that allocation panics (OOM), the original `inner` is
+    /// untouched and `Dynamic::drop` zeroizes the secret during unwind. Confidentiality
+    /// is preserved on the panic path. See the per-impl docs on
+    /// [`Dynamic`](crate::Dynamic) for the exact pattern.
+    ///
     /// # Examples
     ///
     /// ```rust

--- a/secure-gate-core/src/traits/revealed_secrets/encoded_secret.rs
+++ b/secure-gate-core/src/traits/revealed_secrets/encoded_secret.rs
@@ -12,6 +12,15 @@
 //! This is **not** a secret wrapper like [`Fixed`](crate::Fixed) / [`Dynamic`](crate::Dynamic)
 //! — it is a zeroizing `String` wrapper for encoded output. It implements
 //! `Deref<Target = str>` and `Display`.
+//!
+//! # `Display` is intentionally transparent
+//!
+//! Unlike `Debug` (which always prints `[REDACTED]`), `Display` (`{}`) outputs the
+//! encoded secret content verbatim — needed so the value can be written to a sink,
+//! used in format strings, or sent over a wire. **Do not log `EncodedSecret` values
+//! with `{}` in production.** Prefer `{:?}` for diagnostic output to avoid accidental
+//! secret exposure in log files. See the [`Display`] impl on [`EncodedSecret`] for
+//! the same warning at the type-doc level.
 
 #[cfg(feature = "alloc")]
 /// Owned wrapper for encoded secret strings. Guarantees zeroization on drop


### PR DESCRIPTION
## Summary

Six docs-only improvements + a `Cargo.lock` refresh, surfaced by an independent v0.9.0 stable security sweep. **No code-behavior changes.**

## Changes

- **`Cargo.lock`** — refresh from `0.9.0-rc.6-dev` → `0.9.0` (matches workspace `Cargo.toml` since the v0.9.0 stable bump in `c6625f3`).
- **`fixed_alias!` macro** — move `#[doc = $doc]` off the anonymous `const _:` zero-size guard onto the type alias itself. The previous order silently dropped user-supplied doc strings; `dynamic_alias!` already had this right.
- **`ConstantTimeEq` module doc** — add explicit note that length is not constant-time for variable-length inputs (`Vec<u8>` / `String` / `[u8]`); recommend fixed-size types when length itself is sensitive.
- **`FromHexStr` / `FromBase64UrlStr` / `FromBech32Str` / `FromBech32mStr`** — promote the "wrap immediately" guidance from module-level prose into each trait's RustDoc, since callers often read only the trait page.
- **`EncodedSecret` module doc** — hoist the existing `Display` warning from the `Display` impl up to module level so readers who only browse the module intro see "do not log with `{}` in production" before any usage example.
- **`RevealSecret::into_inner`** trait method — cross-reference per-impl allocation behavior (`Fixed` = zero-cost; `Dynamic` = 24-byte sentinel, panic-safe).

## Audit context

This PR lands the docs-only fallout from a multi-lens audit of the v0.9.0 stable surface. Headline verdict: **production-ready, no critical findings, no security code changes required.** The crate's zeroize-on-drop guarantee is backed by a 4-layer evidence chain (semantic `PanicOnNonZeroDrop` + `needs_drop` regression guard + `ProxyAllocator` physical verification + LLVM-level DSE asm check) that exceeds comparable secrets crates. Anti-hallucination doc structure (recently merged in #118 / #120) is well-executed. SECURITY.md is honest about every limitation.

The only material doc bug found is the `fixed_alias!` `#[doc]` placement — silently dropping user-supplied doc strings was a small but real docs regression.

## Test plan

- [x] `cargo build -p secure-gate --features=full` — clean.
- [x] `cargo test -p secure-gate --features=full --doc` — 73 doctests pass (incl. `fixed_alias` zero-size compile-fail check).
- [x] `cargo test -p secure-gate --features=full --tests -- --skip fixed_alias_zero_size_compile_fail --skip serializable_secret_misuse` — all 231 tests pass (same skips as `ci.yml` for stable-toolchain trybuild drift).
- [ ] CI run on this PR (lint × 6 packages, test × 20 feature combos, MSRV 1.85, ASan heap, DSE asm check on stable+nightly).

A parallel PR with the same docs polish (sans `Cargo.lock` refresh) targeting `release/0.8` is being opened separately.

https://claude.ai/code/session_01Ai7BuxYTmi8iSA1ZDNZgr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai7BuxYTmi8iSA1ZDNZgr9)_