### PR TITLE
release: prepare v0.8.0 LTS for crates.io publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-08
+
+### Release Notes
+
+- **Stable v0.8.0 release** — First stable version of the 0.8 LTS series (Rust edition 2021, MSRV 1.70).
+- Sister to the v0.9.0 stable release on `main` (Rust edition 2024, MSRV 1.85). Functionality, security model, and test coverage are at parity; the two lines diverge only on toolchain floor and a small set of dependency surfaces (`rand` 0.9 vs 0.10, `subtle` 2.5 vs 2.6, `zeroize` 1.7 vs 1.8, `base16ct` 0.2 vs 1, `base64ct` =1.6 vs 1).
+- Major security and architectural improvements from the 0.8.0 security overhaul (real `Drop` + zeroize, 3-tier access model, opt-in marker-trait gating, panic-safe `from_protected_bytes`, allocator-level zeroize verification via `ProxyAllocator`, LLVM-level DSE asm regression guard) are now considered mature and production-ready on this LTS line.
+- Clean workspace separation between `secure-gate` (core) and `secure-gate-compat`.
+- Comprehensive testing, zeroization verification, and documentation finalized.
+- Recommended for users on Rust 1.70–1.84 who cannot move to edition 2024; users on Rust 1.85+ should prefer `secure-gate = "0.9"`.
+
+See the per-crate changelogs for detailed changes:
+
+- [`secure-gate-core/CHANGELOG.md`](secure-gate-core/CHANGELOG.md)
+- [`secure-gate-compat/CHANGELOG.md`](secure-gate-compat/CHANGELOG.md)
+
 ## [0.8.0-rc.7] - 2026-03-30
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Release Notes
 
 - **Stable v0.8.0 release** — First stable version of the 0.8 LTS series (Rust edition 2021, MSRV 1.70).
-- Sister to the v0.9.0 stable release on `main` (Rust edition 2024, MSRV 1.85). Functionality, security model, and test coverage are at parity; the two lines diverge only on toolchain floor and a small set of dependency surfaces (`rand` 0.9 vs 0.10, `subtle` 2.5 vs 2.6, `zeroize` 1.7 vs 1.8, `base16ct` 0.2 vs 1, `base64ct` =1.6 vs 1).
+- Parallel to the v0.9.0 stable release on `main` (Rust edition 2024, MSRV 1.85). Functionality, security model, and test coverage are at parity; the two lines diverge only on toolchain floor and a small set of dependency surfaces (`rand` 0.9 vs 0.10, `subtle` 2.5 vs 2.6, `zeroize` 1.7 vs 1.8, `base16ct` 0.2 vs 1, `base64ct` =1.6 vs 1).
 - Major security and architectural improvements from the 0.8.0 security overhaul (real `Drop` + zeroize, 3-tier access model, opt-in marker-trait gating, panic-safe `from_protected_bytes`, allocator-level zeroize verification via `ProxyAllocator`, LLVM-level DSE asm regression guard) are now considered mature and production-ready on this LTS line.
 - Clean workspace separation between `secure-gate` (core) and `secure-gate-compat`.
 - Comprehensive testing, zeroization verification, and documentation finalized.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "secure-gate"
-version = "0.8.0-rc.9-dev"
+version = "0.8.0"
 dependencies = [
  "base16ct",
  "base64ct",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "secure-gate-compat"
-version = "0.8.0-rc.9-dev"
+version = "0.8.0"
 dependencies = [
  "proptest",
  "secrecy 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["secure-gate-core/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0-rc.9-dev"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # secure-gate workspace
 
-[![Docs.rs](https://docs.rs/secure-gate/badge.svg)](https://docs.rs/secure-gate/0.8.0-rc.9/secure_gate/)
+[![Docs.rs](https://docs.rs/secure-gate/badge.svg)](https://docs.rs/secure-gate/0.8.0/secure_gate/)
 [![CI](https://github.com/Slurp9187/secure-gate/actions/workflows/ci.yml/badge.svg?branch=release%2F0.8)](https://github.com/Slurp9187/secure-gate/actions/workflows/ci.yml?query=branch%3Arelease%2F0.8)
 [![MSRV: 1.70](https://img.shields.io/badge/msrv-1.70-blue)](https://github.com/Slurp9187/secure-gate/blob/release/0.8/Cargo.toml)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)

--- a/secure-gate-compat/CHANGELOG.md
+++ b/secure-gate-compat/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-08
+
+### Release Notes
+
+- **Stable v0.8.0 release** — First stable version of the compat shim on the 0.8 LTS line (Rust edition 2021, MSRV 1.70). Tracks `secure-gate = "0.8"`.
+- No API changes since `0.8.0-rc.7`; all `secrecy` v0.8 / v0.10 migration shims (`Secret`, `SecretBox`, `SecretString`, `SecretSlice`, `SecretVec`, `DebugSecret`) plus dual-version parity tests, fuzz targets, and migration guide are considered stable.
+- Recommended for teams migrating off `secrecy` who target Rust 1.70+. Prefer dropping the `secrecy-compat` feature once migration is complete.
+
 ## [0.8.0-rc.7] - 2026-03-30
 
 ### Changed

--- a/secure-gate-core/CHANGELOG.md
+++ b/secure-gate-core/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Release Notes
 
-- **Stable v0.8.0 release** — First stable version of the 0.8 LTS line (Rust edition 2021, MSRV 1.70). Sister to v0.9.0 on `main`.
+- **Stable v0.8.0 release** — First stable version of the 0.8 LTS line (Rust edition 2021, MSRV 1.70). Parallel to v0.9.0 on `main`.
 - Security model, test coverage, and zeroization evidence chain (semantic `PanicOnNonZeroDrop` + `needs_drop` regression guard + `ProxyAllocator` physical verification + LLVM-level DSE asm check) are at parity with v0.9.0.
 - Recommended for users on Rust 1.70–1.84 who cannot move to edition 2024.
 

--- a/secure-gate-core/CHANGELOG.md
+++ b/secure-gate-core/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-08
+
+### Release Notes
+
+- **Stable v0.8.0 release** — First stable version of the 0.8 LTS line (Rust edition 2021, MSRV 1.70). Sister to v0.9.0 on `main`.
+- Security model, test coverage, and zeroization evidence chain (semantic `PanicOnNonZeroDrop` + `needs_drop` regression guard + `ProxyAllocator` physical verification + LLVM-level DSE asm check) are at parity with v0.9.0.
+- Recommended for users on Rust 1.70–1.84 who cannot move to edition 2024.
+
+### Documentation (post-audit polish)
+
+- `fixed_alias!` macro: move `#[doc = $doc]` off the anonymous `const _:` zero-size guard onto the type alias itself. The previous order silently dropped user-supplied doc strings.
+- `ConstantTimeEq` module doc: explicit note that length is not constant-time for variable-length inputs (`Vec<u8>` / `String` / `[u8]`); recommend fixed-size types when length is sensitive.
+- `FromHexStr` / `FromBase64UrlStr` / `FromBech32Str` / `FromBech32mStr` trait docs: promote the "wrap immediately" guidance into each trait's RustDoc.
+- `EncodedSecret` module doc: hoist the existing `Display` warning ("do not log with `{}` in production") to module level.
+- `RevealSecret::into_inner` trait method: cross-reference per-impl allocation behavior (`Fixed` = zero-cost; `Dynamic` = 24-byte sentinel, panic-safe).
+
 ## [0.8.0-rc.8] - 2026-04-03
 
 ### Added

--- a/secure-gate-core/README.md
+++ b/secure-gate-core/README.md
@@ -1,6 +1,6 @@
 # secure-gate
 
-[![Docs.rs](https://docs.rs/secure-gate/badge.svg)](https://docs.rs/secure-gate/0.8.0-rc.9/secure_gate/)
+[![Docs.rs](https://docs.rs/secure-gate/badge.svg)](https://docs.rs/secure-gate/0.8.0/secure_gate/)
 [![CI](https://github.com/Slurp9187/secure-gate/actions/workflows/ci.yml/badge.svg?branch=release%2F0.8)](https://github.com/Slurp9187/secure-gate/actions/workflows/ci.yml?query=branch%3Arelease%2F0.8)
 [![MSRV: 1.70](https://img.shields.io/badge/msrv-1.70-blue)](https://github.com/Slurp9187/secure-gate/blob/release/0.8/Cargo.toml)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
@@ -156,19 +156,19 @@ fn log_length<S: RevealSecret>(secret: &S) {
 
 ```toml
 [dependencies]
-secure-gate = "0.8.0-rc.{x}"
+secure-gate = "0.8"
 ```
 
 **No-heap / embedded** (`Fixed<T>` only — pure stack / `no_std`):
 
 ```toml
-secure-gate = { version = "0.8.0-rc.{x}", default-features = false }
+secure-gate = { version = "0.8", default-features = false }
 ```
 
 **Batteries-included**:
 
 ```toml
-secure-gate = { version = "0.8.0-rc.{x}", features = ["full"] }
+secure-gate = { version = "0.8", features = ["full"] }
 ```
 
 ## Encoding & Decoding


### PR DESCRIPTION
## Summary

Bundles everything needed to make `release/0.8` publish-ready as `secure-gate v0.8.0` + `secure-gate-compat v0.8.0`. Three commit groups:

1. **Version bump** (`9a63cc1`) — workspace `0.8.0-rc.9-dev` → `0.8.0`, Cargo.lock refresh, CHANGELOG entries, README install snippets pinned to `"0.8"`.
2. **Framing reframe** (`dcd51a9` + `d2e99e6`) — replace "sister" with "parallel" and "post-audit polish" with "post-review polish" so this work isn't conflated with a formal third-party security audit.
3. **Packaging readiness** (`8f5c7cc`) — fix the publish-blocking missing `version` on the compat dep, bundle `LICENSE-MIT`/`LICENSE-APACHE` into both subcrates, and add `CHANGELOG.md`/`README.md`/`SECURITY.md` to the compat include list.

## Background — code review, not formal audit

The work that produced this release sequence was an **LLM-driven code review with a security focus** ([prior session notes, PR #122](https://github.com/Slurp9187/secure-gate/pull/122) on `main`; [PR #123](https://github.com/Slurp9187/secure-gate/pull/123) on `release/0.8`). It is **not** a formal/independent third-party security audit — that has not happened yet. The project `README.md` and `SECURITY.md` remain the source of truth on this point: *"this crate has not undergone an independent security audit"*.

What the review **did** confirm: `release/0.8` is in **the same security posture as v0.9** along the dimensions a code review can check from source — same multi-layer zeroize evidence chain (semantic `PanicOnNonZeroDrop` + `needs_drop` regression guard + `ProxyAllocator` physical verification + LLVM-level DSE asm check), same panic-safe `from_protected_bytes` pattern, same 3-tier access model, same opt-in marker-trait gating. The two lines diverge only on toolchain floor and a small set of dep surfaces (`rand` 0.9 / `subtle` 2.5 / `zeroize` 1.7 / `base16ct` 0.2 / `base64ct` =1.6).

## Changes in detail

### Version bump + CHANGELOG

- **`Cargo.toml`** — workspace `version = "0.8.0-rc.9-dev"` → `"0.8.0"`.
- **`Cargo.lock`** — refreshed.
- **`CHANGELOG.md`** (workspace) — close `[Unreleased]`, add `[0.8.0] - 2026-05-08` release entry.
- **`secure-gate-core/CHANGELOG.md`** — matching `[0.8.0]` entry; folds in the post-review docs polish from PR #123 under "Documentation (post-review polish)".
- **`secure-gate-compat/CHANGELOG.md`** — matching `[0.8.0]` entry; no API changes since rc.7.
- **`README.md`** (workspace + core) — pin the docs.rs badge link to `/0.8.0/`, drop the `0.8.0-rc.{x}` placeholder from install snippets in the core README (now plain `secure-gate = "0.8"`).

### Packaging fixes (publish-readiness)

- **HARD blocker fixed**: `secure-gate-compat`'s `secure-gate` dep had `path` but no `version`. Cargo refuses to publish such manifests. Added `version = "0.8.0"`.
- **License files**: `LICENSE-MIT` + `LICENSE-APACHE` now exist in both subcrate directories so they're actually bundled in the `.crate` artifact (previously the workspace-root copies were never included).
- **Compat include list**: added `CHANGELOG.md`, `README.md`, `SECURITY.md` to the existing curated include list. Without `README.md` the docs.rs front page would have rendered empty.

## Recommendation

> Recommended for users on Rust 1.70–1.84 who cannot migrate to edition 2024. Users on Rust 1.85+ should prefer `secure-gate = "0.9"`.

Same caveat as v0.9.0: no independent third-party security audit has been performed; review the source and SECURITY.md before production use, and prefer to commission a formal audit before security-critical deployment.

## Test plan

- [x] `cargo build -p secure-gate --features=full` — clean (rand 0.9 / OsRng / TryRngCore).
- [x] `cargo test -p secure-gate --features=full --tests -- --skip fixed_alias_zero_size_compile_fail --skip serializable_secret_misuse` — 212 / 212 ✓ (same skips as `ci.yml` for stable-toolchain trybuild drift).
- [x] `cargo test -p secure-gate --features=full --doc` — 74 / 74 ✓.
- [x] `cd secure-gate-core && cargo publish --dry-run --allow-dirty` — clean (38 files, 336.4 KiB packaged).
- [x] `cd secure-gate-compat && cargo package --no-verify --list` — 14 files, no test infrastructure bundled, all docs + LICENSE + MIGRATING included.
- [ ] CI on this PR.
- [ ] After merge: tag and publish manually, **`secure-gate` first, then `secure-gate-compat`** (the compat dry-run intentionally fails today on dep resolution because `secure-gate = ^0.8.0` doesn't exist on crates.io yet).

## Relationship to other PRs

- **#123** (post-review docs polish for `release/0.8`) — already merged.
- **#125** (parallel work on `main` for v0.9.0) — independent, no file overlap.

https://claude.ai/code/session_01Ai7BuxYTmi8iSA1ZDNZgr9