### PR TITLE
release: complete v0.9.0 propagation + crates.io publish-readiness

### DIFF
--- a/secure-gate-compat/CHANGELOG.md
+++ b/secure-gate-compat/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Stable v0.9.0 release** — First stable version of the compat shim on the 0.9 line (Rust edition 2024, MSRV 1.85). Tracks `secure-gate = "0.9"`.
 - No API changes since `0.9.0-rc.5`; all `secrecy` v0.8 / v0.10 migration shims (`Secret`, `SecretBox`, `SecretString`, `SecretSlice`, `SecretVec`, `DebugSecret`) plus dual-version parity tests, fuzz targets, and migration guide are considered stable.
-- Sister to v0.8.0 on `release/0.8` (Rust 2021 / MSRV 1.70).
+- Parallel to v0.8.0 on `release/0.8` (Rust 2021 / MSRV 1.70).
 - Recommended for teams migrating off `secrecy` who target Rust 1.85+. Prefer dropping the `secrecy-compat` feature once migration is complete.
 
 ## [0.9.0-rc.5] - 2026-04-03

--- a/secure-gate-compat/CHANGELOG.md
+++ b/secure-gate-compat/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-08
+
+### Release Notes
+
+- **Stable v0.9.0 release** — First stable version of the compat shim on the 0.9 line (Rust edition 2024, MSRV 1.85). Tracks `secure-gate = "0.9"`.
+- No API changes since `0.9.0-rc.5`; all `secrecy` v0.8 / v0.10 migration shims (`Secret`, `SecretBox`, `SecretString`, `SecretSlice`, `SecretVec`, `DebugSecret`) plus dual-version parity tests, fuzz targets, and migration guide are considered stable.
+- Sister to v0.8.0 on `release/0.8` (Rust 2021 / MSRV 1.70).
+- Recommended for teams migrating off `secrecy` who target Rust 1.85+. Prefer dropping the `secrecy-compat` feature once migration is complete.
+
 ## [0.9.0-rc.5] - 2026-04-03
 
 ### Documentation

--- a/secure-gate-core/CHANGELOG.md
+++ b/secure-gate-core/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Release Notes
 
 - **Stable v0.9.0 release** — First stable version of the 0.9 series (Rust edition 2024, MSRV 1.85).
-- Sister to the v0.8.0 LTS line on `release/0.8` (Rust edition 2021, MSRV 1.70). Functionality, security model, and test coverage are at parity; the two lines diverge only on toolchain floor and a small set of dependency surfaces (`rand` 0.10 vs 0.9, `subtle` 2.6 vs 2.5, `zeroize` 1.8 vs 1.7, `base16ct` 1 vs 0.2, `base64ct` 1 vs =1.6).
+- Parallel to the v0.8.0 LTS line on `release/0.8` (Rust edition 2021, MSRV 1.70). Functionality, security model, and test coverage are at parity; the two lines diverge only on toolchain floor and a small set of dependency surfaces (`rand` 0.10 vs 0.9, `subtle` 2.6 vs 2.5, `zeroize` 1.8 vs 1.7, `base16ct` 1 vs 0.2, `base64ct` 1 vs =1.6).
 - Major security and architectural improvements from the 0.8.0 security overhaul (real `Drop` + zeroize, 3-tier access model, opt-in marker-trait gating, panic-safe `from_protected_bytes`, allocator-level zeroize verification via `ProxyAllocator`, LLVM-level DSE asm regression guard) are now considered mature and production-ready on this line.
 - Clean workspace separation between `secure-gate` (core) and `secure-gate-compat`.
 - Comprehensive testing, zeroization verification, and documentation finalized.

--- a/secure-gate-core/CHANGELOG.md
+++ b/secure-gate-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-08
+
+### Release Notes
+
+- **Stable v0.9.0 release** — First stable version of the 0.9 series (Rust edition 2024, MSRV 1.85).
+- Sister to the v0.8.0 LTS line on `release/0.8` (Rust edition 2021, MSRV 1.70). Functionality, security model, and test coverage are at parity; the two lines diverge only on toolchain floor and a small set of dependency surfaces (`rand` 0.10 vs 0.9, `subtle` 2.6 vs 2.5, `zeroize` 1.8 vs 1.7, `base16ct` 1 vs 0.2, `base64ct` 1 vs =1.6).
+- Major security and architectural improvements from the 0.8.0 security overhaul (real `Drop` + zeroize, 3-tier access model, opt-in marker-trait gating, panic-safe `from_protected_bytes`, allocator-level zeroize verification via `ProxyAllocator`, LLVM-level DSE asm regression guard) are now considered mature and production-ready on this line.
+- Clean workspace separation between `secure-gate` (core) and `secure-gate-compat`.
+- Comprehensive testing, zeroization verification, and documentation finalized.
+- Recommended for users on Rust 1.85+; users on Rust 1.70–1.84 should use `secure-gate = "0.8"` (LTS).
+
 ## [0.9.0-rc.5] - 2026-04-03
 
 ### Documentation

--- a/secure-gate-core/README.md
+++ b/secure-gate-core/README.md
@@ -145,19 +145,19 @@ fn log_length<S: RevealSecret>(secret: &S) {
 
 ```toml
 [dependencies]
-secure-gate = "0.9.0-rc.{x}"
+secure-gate = "0.9"
 ```
 
 **No-heap / embedded** (`Fixed<T>` only — pure stack / `no_std`):
 
 ```toml
-secure-gate = { version = "0.9.0-rc.{x}", default-features = false }
+secure-gate = { version = "0.9", default-features = false }
 ```
 
 **Batteries-included**:
 
 ```toml
-secure-gate = { version = "0.9.0-rc.{x}", features = ["full"] }
+secure-gate = { version = "0.9", features = ["full"] }
 ```
 
 ## Encoding & Decoding


### PR DESCRIPTION
## Summary

The v0.9.0 stable bump (commits `5fce546` / `c6625f3` on `main`) closed `[Unreleased]` on the **workspace** `CHANGELOG.md` but left a number of release artifacts in pre-release shape. This PR finishes the propagation and also makes both crates actually publishable on crates.io.

Two commit groups:

1. **Documentation propagation** (`f7888a9` + `fda1469`) — adds the missing per-crate `[0.9.0]` CHANGELOG entries; replaces stale `0.9.0-rc.{x}` install snippets in the core README; replaces "sister" with "parallel" framing.
2. **Packaging readiness** (`daf73c5`) — fixes the publish-blocking missing `version` on the compat dep, bundles `LICENSE-MIT`/`LICENSE-APACHE` into both subcrates, ports the curated include directive + metadata from `release/0.8`, removes a dead include entry from core.

## Review context — code review, not formal audit

This was a code review (not a formal/independent third-party audit) of release-readiness state. The project `README.md` and `SECURITY.md` continue to be the source of truth: *"this crate has not undergone an independent security audit"*.

## Findings matrix on `main` before this PR

| Artifact | Status |
|---|---|
| `Cargo.toml` workspace `version = "0.9.0"` | ✅ correct |
| `Cargo.lock` (`secure-gate v0.9.0`, `secure-gate-compat v0.9.0`) | ✅ correct (refreshed in PR #122) |
| Workspace `CHANGELOG.md` `[0.9.0]` entry | ✅ correct |
| `README.md` (workspace) — `secure-gate = "0.9"` | ✅ correct |
| `secure-gate-compat/README.md` — `secure-gate-compat = { version = "0.9", … }` | ✅ correct |
| `secure-gate-core/CHANGELOG.md` `[0.9.0]` entry | ❌ **missing** — top entry was still `[0.9.0-rc.5]` |
| `secure-gate-compat/CHANGELOG.md` `[0.9.0]` entry | ❌ **missing** — same |
| `secure-gate-core/README.md` install snippets | ❌ **stale** — three snippets still said `secure-gate = "0.9.0-rc.{x}"` |
| `secure-gate-compat` `secure-gate` dep has a `version` | ❌ **HARD publish blocker** — `cargo publish` refuses without one |
| `LICENSE-MIT` / `LICENSE-APACHE` bundled in `.crate` artifacts | ❌ **missing** — `LICENSE*` glob is package-relative; files only existed at workspace root |
| `secure-gate-compat` ships a curated set of files | ❌ — no `include` directive, so `tests/` + `scripts/` + `compile-fail/.stderr` got bundled |
| `secure-gate-compat` has `documentation` / `keywords` / `categories` metadata | ❌ — only `release/0.8` had these |
| `secure-gate-core/Cargo.toml` include list is clean | ❌ — listed `MIGRATING_FROM_SECRECY.md` (which lives in compat) |

## Changes

### Documentation propagation (commits `f7888a9` + `fda1469`)

- **`secure-gate-core/CHANGELOG.md`** — add `[0.9.0] - 2026-05-08` release entry.
- **`secure-gate-compat/CHANGELOG.md`** — matching `[0.9.0]` entry; no API changes since rc.5.
- **`secure-gate-core/README.md`** — strip the `0.9.0-rc.{x}` placeholder from the three install snippets, replace with plain `"0.9"`.
- Replace "sister" → "parallel" (gendered → topology-precise; gender-neutral).

### Packaging fixes (commit `daf73c5`)

- **HARD blocker fixed**: added `version = "0.9.0"` to the `secure-gate` dep in `secure-gate-compat/Cargo.toml`. Cargo refuses to publish a manifest with `path` but no `version`.
- **License files**: copied `LICENSE-MIT` + `LICENSE-APACHE` into both `secure-gate-core/` and `secure-gate-compat/` so they're bundled in the `.crate` artifact.
- **Include list ported from v0.8**: `secure-gate-compat/Cargo.toml` now has an explicit include list (mirrors `secure-gate-core` shape: `src/**/*.rs`, `CHANGELOG.md`, `LICENSE*`, `MIGRATING_FROM_SECRECY.md`, `README.md`, `SECURITY.md`). Drops `tests/`, `scripts/`, `compile-fail/.stderr` from the `.crate`.
- **Metadata parity**: `secure-gate-compat/Cargo.toml` now has the `documentation`, `keywords`, `categories`, and a curated `description` that match the `release/0.8` manifest.
- **Dead include cleanup**: removed `MIGRATING_FROM_SECRECY.md` from `secure-gate-core/Cargo.toml`'s include list (file lives in compat; entry was a silent no-op).

No source-code changes; no behavior changes.

## Test plan

- [x] `cargo build -p secure-gate --features=full` — clean.
- [x] `cargo test -p secure-gate --features=full --doc` — 73 / 73 + 1 / 1 ✓.
- [x] `cd secure-gate-core && cargo publish --dry-run --allow-dirty` — clean.
- [x] `cd secure-gate-compat && cargo package --no-verify --list` — 14 files, no test infrastructure bundled, all docs + LICENSE + MIGRATING included.
- [ ] CI on this PR.
- [ ] After merge: tag and publish manually, **`secure-gate` first, then `secure-gate-compat`** (the compat dry-run intentionally fails today on dep resolution because `secure-gate = ^0.9.0` doesn't exist on crates.io yet).

## Relationship to other PRs

- **#122** — already merged. Audit polish + Cargo.lock refresh on `main`.
- **#123** / **#124** — release/0.8 LTS post-review polish + v0.8.0 stable bump (parallel track).

https://claude.ai/code/session_01Ai7BuxYTmi8iSA1ZDNZgr9