### PR TITLE
Restructure into workspace with secure-gate-core and secure-gate-compat

### DIFF
--- a/secure-gate-core/CHANGELOG.md
+++ b/secure-gate-core/CHANGELOG.md
@@ -56,6 +56,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the ergonomic and performance trade-offs (`FnOnce` → `FnMut`, no direct return
   value, dynamic dispatch overhead).
 
+### Breaking
+
+- **`RevealSecret::len()` now returns element count.** Previously all impls returned
+  `n_elements * size_of::<T>()` (bytes), which is correct only for `T = u8` and
+  violates Rust's universal `len()` = element-count contract (`Vec::len`,
+  `slice::len`, etc.). Fixed impls now return element count (`inner.len()` for
+  `Dynamic<Vec<T>>`, `N` for `Fixed<[T; N]>`). A new provided method
+  `RevealSecret::byte_len()` returns the byte size and is overridden for multi-byte
+  element types. **Behavior is unchanged** for the common cases `Dynamic<Vec<u8>>`,
+  `Dynamic<String>`, and `Fixed<[u8; N]>`.
+
 ### Documentation (post-review polish)
 
 - `fixed_alias!` macro: move `#[doc = $doc]` off the anonymous `const _:` zero-size guard onto the type alias itself. The previous order silently dropped user-supplied doc strings.

--- a/secure-gate-core/src/dynamic.rs
+++ b/secure-gate-core/src/dynamic.rs
@@ -504,6 +504,11 @@ impl<T: zeroize::Zeroize> crate::RevealSecret for Dynamic<Vec<T>> {
 
     #[inline(always)]
     fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[inline(always)]
+    fn byte_len(&self) -> usize {
         self.inner.len() * core::mem::size_of::<T>()
     }
 

--- a/secure-gate-core/src/fixed.rs
+++ b/secure-gate-core/src/fixed.rs
@@ -855,6 +855,11 @@ impl<const N: usize, T: zeroize::Zeroize> RevealSecret for Fixed<[T; N]> {
 
     #[inline(always)]
     fn len(&self) -> usize {
+        N
+    }
+
+    #[inline(always)]
+    fn byte_len(&self) -> usize {
         N * core::mem::size_of::<T>()
     }
 

--- a/secure-gate-core/src/traits/reveal_secret.rs
+++ b/secure-gate-core/src/traits/reveal_secret.rs
@@ -181,10 +181,24 @@ pub trait RevealSecret {
     /// ```
     fn expose_secret(&self) -> &Self::Inner;
 
-    /// Returns the length of the secret in bytes.
+    /// Returns the number of elements in the secret, matching the underlying
+    /// container's `len()` — element count for `Vec<T>` and `[T; N]`, byte count
+    /// for `String`/`str` (where the element is a byte).
     ///
     /// Always safe to call — does not expose secret contents.
     fn len(&self) -> usize;
+
+    /// Returns the total size of the secret in bytes.
+    ///
+    /// For single-byte element types (`Vec<u8>`, `String`, `[u8; N]`) this equals
+    /// `len()`. For multi-byte element types override this method to return
+    /// `len() * core::mem::size_of::<T>()`.
+    ///
+    /// Always safe to call — does not expose secret contents.
+    #[inline(always)]
+    fn byte_len(&self) -> usize {
+        self.len()
+    }
 
     /// Returns `true` if the secret is empty.
     ///

--- a/secure-gate-core/tests/core_tests.rs
+++ b/secure-gate-core/tests/core_tests.rs
@@ -409,3 +409,35 @@ fn dynamic_from_rng_error_returns_err() {
     let result = Dynamic::<Vec<u8>>::from_rng(32, &mut FailingRng);
     assert!(result.is_err());
 }
+
+// === len() element-count semantics ===
+
+#[cfg(feature = "alloc")]
+#[test]
+fn dynamic_vec_u32_len_is_element_count() {
+    let secret: Dynamic<Vec<u32>> = Dynamic::from(vec![0u32; 4]);
+    assert_eq!(secret.len(), 4);
+    assert_eq!(secret.byte_len(), 16);
+}
+
+#[test]
+fn fixed_u32_len_is_element_count() {
+    let secret: Fixed<[u32; 4]> = Fixed::new([0u32; 4]);
+    assert_eq!(secret.len(), 4);
+    assert_eq!(secret.byte_len(), 16);
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn dynamic_vec_u8_len_unchanged() {
+    let secret: Dynamic<Vec<u8>> = Dynamic::from(vec![0u8; 8]);
+    assert_eq!(secret.len(), 8);
+    assert_eq!(secret.byte_len(), 8);
+}
+
+#[test]
+fn fixed_u8_len_unchanged() {
+    let secret: Fixed<[u8; 8]> = Fixed::new([0u8; 8]);
+    assert_eq!(secret.len(), 8);
+    assert_eq!(secret.byte_len(), 8);
+}


### PR DESCRIPTION
## Summary

This PR restructures the `secure-gate` project from a single crate into a workspace with two member crates:

- **`secure-gate-core`**: The main library containing `Fixed<T>`, `Dynamic<T>`, and all encoding/decoding traits
- **`secure-gate-compat`**: A new compatibility layer providing drop-in replacements for the `secrecy` crate (v0.8.0 and v0.10.1)

## Key Changes

- **Workspace structure**: Converted root `Cargo.toml` to workspace manifest; moved core implementation to `secure-gate-core/`
- **New compatibility crate**: Added `secure-gate-compat` with `compat::v08` and `compat::v10` modules that mirror the `secrecy` API exactly, enabling incremental migration
- **Expanded test suite**: 
  - Added comprehensive compat tests (`compat_suite/`, `compat_dual/`, `proptest_suite/`)
  - Added migration integration tests and parity tests against real `secrecy` crate
  - Added compile-fail tests for API guarantees (no `Deref`, no `AsRef`, etc.)
- **Documentation**: Added `MIGRATING_FROM_SECRECY.md`, expanded `SECURITY.md`, added `ROADMAP.md`
- **CI/CD updates**: Modified GitHub workflows to target `release/0.8` branch; added DSE (dead-store elimination) verification workflow
- **Security fixes**: Documented findings in `CHANGELOG.md` (Finding 1: `Dynamic::new_with` closure-panic leak mitigation)
- **Code organization**: Reorganized traits into submodules (`encoding/`, `decoding/`, `revealed_secrets/`); added import path documentation to all public traits

## Notable Implementation Details

- Both crates maintain `#![forbid(unsafe_code)]` unconditionally
- Compat layer uses marker traits (`ExposeSecret`, `ExposeSecretMut`) to bridge old and new APIs
- All encoding/decoding traits now have explicit import path documentation (e.g., `use secure_gate::ToHex`)
- Test infrastructure includes property-based tests, assembly-level DSE verification, and dual-test macros for parity checking

https://claude.ai/code/session_01TXpMzKp8HM7tYXB9AGCADJ