### PR TITLE
RC pre-stable housekeeping: metadata fixes + len() element-count semantics

### DIFF
--- a/secure-gate-compat/Cargo.toml
+++ b/secure-gate-compat/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 description = "Compatibility layer providing drop-in secrecy shims for secure-gate"
 repository = "https://github.com/Slurp9187/secure-gate/tree/main/secure-gate-compat"
 documentation = "https://docs.rs/secure-gate-compat"
-keywords = ["crypto", "no-std", "security", "zeroize", "secrecy", "compat"]
+keywords = ["crypto", "security", "zeroize", "secrecy", "compat"]
 categories = ["cryptography", "no-std", "data-structures"]
 include = [
     "src/**/*.rs",

--- a/secure-gate-core/CHANGELOG.md
+++ b/secure-gate-core/CHANGELOG.md
@@ -43,6 +43,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ARM64 and would silently skip the `cfg(target_arch = "x86_64")`-gated
   test.
 
+### Breaking
+
+- **`RevealSecret::len()` now returns element count.** Previously all impls returned
+  `n_elements * size_of::<T>()` (bytes), which is correct only for `T = u8` and
+  violates Rust's universal `len()` = element-count contract (`Vec::len`,
+  `slice::len`, etc.). Fixed impls now return element count (`inner.len()` for
+  `Dynamic<Vec<T>>`, `N` for `Fixed<[T; N]>`). A new provided method
+  `RevealSecret::byte_len()` returns the byte size and is overridden for multi-byte
+  element types. **Behavior is unchanged** for the common cases `Dynamic<Vec<u8>>`,
+  `Dynamic<String>`, and `Fixed<[u8; N]>`.
+
+### Fixed
+
+- **`secure-gate-compat` keyword count.** Dropped `"no-std"` from `Cargo.toml`
+  keywords (crates.io rejects more than 5).
+- **MSRV documentation corrected.** `README.md` and `ROADMAP.md` incorrectly
+  stated `release/0.8` MSRV as 1.75; corrected to 1.70.
+- **`#![forbid(unsafe_code)]` scope clarified.** `SECURITY.md` previously said
+  "enforced unconditionally"; updated to "enforced in the library crate" to
+  reflect that the binary crate `src/bin/asm_check.rs` uses
+  `#[unsafe(no_mangle)]` (Rust 2024 syntax), which is unrelated to the
+  library's guarantee.
+
 ### Documentation
 
 - **`RevealSecret` type-erasure stance clarified (design note).** `Box<dyn

--- a/secure-gate-core/README.md
+++ b/secure-gate-core/README.md
@@ -292,7 +292,7 @@ Full details in [CHANGELOG.md](CHANGELOG.md). Users on Rust < 1.85: pin `secure-
 ## Branch support
 
 Version **0.9.x** (`main`) targets Rust Edition 2024 and MSRV 1.85.  
-For Rust < 1.85, pin `secure-gate = "0.8"` — the `release/0.8` branch (Edition 2021, MSRV 1.75) receives security patches and important backports.
+For Rust < 1.85, pin `secure-gate = "0.8"` — the `release/0.8` branch (Edition 2021, MSRV 1.70) receives security patches and important backports.
 
 ## Migrating from secrecy
 

--- a/secure-gate-core/ROADMAP.md
+++ b/secure-gate-core/ROADMAP.md
@@ -11,13 +11,13 @@ secure-gate is a small, single-developer crate for in-memory secret protection.
 | Branch | Version | Rust edition | MSRV | Status |
 |---|---|---|---|---|
 | `main` | 0.9.x | 2024 | 1.85 | Active development |
-| `release/0.8` | 0.8.x | 2021 | 1.75 | LTS — security patches only |
+| `release/0.8` | 0.8.x | 2021 | 1.70 | LTS — security patches only |
 
 **Users on Rust < 1.85**: pin `secure-gate = "0.8"` in `Cargo.toml`.
 **Modern users (Rust ≥ 1.85)**: use `secure-gate = "0.9"`.
 
 Security fixes and important bug fixes may be backported from `main` to `release/0.8` as patch releases (0.8.x).
-The 0.8 line will receive patches as long as the dependencies it relies on remain compatible with Rust 1.75.
+The 0.8 line will receive patches as long as the dependencies it relies on remain compatible with Rust 1.70.
 
 ---
 

--- a/secure-gate-core/SECURITY.md
+++ b/secure-gate-core/SECURITY.md
@@ -3,7 +3,7 @@
 ## TL;DR
 
 - **No independent audit** — review the source code yourself before production use.
-- **No unsafe code** — `#![forbid(unsafe_code)]` enforced unconditionally.
+- **No unsafe code** — `#![forbid(unsafe_code)]` enforced in the library crate.
 - **3-tier access model** — explicit hierarchy (prefer Tier 1 scoped methods). Audit Tier 2/3 calls separately.
 - **Explicit exposure only** — all external access requires `with_secret`/`expose_secret` (or mutable equivalents); no `Deref`/`AsRef`. Internal impls (`Clone`, `Serialize`) access `.inner` directly by design — they require opt-in marker traits and do not expose secrets to callers.
 - **Zeroization on drop** — full buffer (incl. spare capacity) is wiped (inner type must implement `Zeroize`).
@@ -70,7 +70,7 @@ All secret access follows this explicit hierarchy (the table below expands on th
 | Timing safety                  | `ConstantTimeEq` (`.ct_eq()`) — deterministic constant-time comparison via `expose_secret()`. Avoid `==`.          |
 | Opt-in risky features          | Cloning/serialization gated by marker traits (`CloneableSecret`, `SerializableSecret`)                             |
 | Redacted debug                 | `Debug` impl always prints `[REDACTED]`                                                                            |
-| No unsafe code                 | `#![forbid(unsafe_code)]` enforced at crate level                                                                  |
+| No unsafe code                 | `#![forbid(unsafe_code)]` enforced in the library crate                                                            |
 
 
 ## Feature Security Implications

--- a/secure-gate-core/src/dynamic.rs
+++ b/secure-gate-core/src/dynamic.rs
@@ -504,6 +504,11 @@ impl<T: zeroize::Zeroize> crate::RevealSecret for Dynamic<Vec<T>> {
 
     #[inline(always)]
     fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[inline(always)]
+    fn byte_len(&self) -> usize {
         self.inner.len() * core::mem::size_of::<T>()
     }
 

--- a/secure-gate-core/src/fixed.rs
+++ b/secure-gate-core/src/fixed.rs
@@ -855,6 +855,11 @@ impl<const N: usize, T: zeroize::Zeroize> RevealSecret for Fixed<[T; N]> {
 
     #[inline(always)]
     fn len(&self) -> usize {
+        N
+    }
+
+    #[inline(always)]
+    fn byte_len(&self) -> usize {
         N * core::mem::size_of::<T>()
     }
 

--- a/secure-gate-core/src/traits/reveal_secret.rs
+++ b/secure-gate-core/src/traits/reveal_secret.rs
@@ -180,10 +180,24 @@ pub trait RevealSecret {
     /// ```
     fn expose_secret(&self) -> &Self::Inner;
 
-    /// Returns the length of the secret in bytes.
+    /// Returns the number of elements in the secret, matching the underlying
+    /// container's `len()` — element count for `Vec<T>` and `[T; N]`, byte count
+    /// for `String`/`str` (where the element is a byte).
     ///
     /// Always safe to call — does not expose secret contents.
     fn len(&self) -> usize;
+
+    /// Returns the total size of the secret in bytes.
+    ///
+    /// For single-byte element types (`Vec<u8>`, `String`, `[u8; N]`) this equals
+    /// `len()`. For multi-byte element types override this method to return
+    /// `len() * core::mem::size_of::<T>()`.
+    ///
+    /// Always safe to call — does not expose secret contents.
+    #[inline(always)]
+    fn byte_len(&self) -> usize {
+        self.len()
+    }
 
     /// Returns `true` if the secret is empty.
     ///

--- a/secure-gate-core/tests/core_tests.rs
+++ b/secure-gate-core/tests/core_tests.rs
@@ -443,3 +443,35 @@ fn dynamic_from_rng_error_returns_err() {
     let result = Dynamic::<Vec<u8>>::from_rng(32, &mut FailingRng);
     assert!(result.is_err());
 }
+
+// === len() element-count semantics (issue #5) ===
+
+#[cfg(feature = "alloc")]
+#[test]
+fn dynamic_vec_u32_len_is_element_count() {
+    let secret: Dynamic<Vec<u32>> = Dynamic::from(vec![0u32; 4]);
+    assert_eq!(secret.len(), 4);
+    assert_eq!(secret.byte_len(), 16);
+}
+
+#[test]
+fn fixed_u32_len_is_element_count() {
+    let secret: Fixed<[u32; 4]> = Fixed::new([0u32; 4]);
+    assert_eq!(secret.len(), 4);
+    assert_eq!(secret.byte_len(), 16);
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn dynamic_vec_u8_len_unchanged() {
+    let secret: Dynamic<Vec<u8>> = Dynamic::from(vec![0u8; 8]);
+    assert_eq!(secret.len(), 8);
+    assert_eq!(secret.byte_len(), 8);
+}
+
+#[test]
+fn fixed_u8_len_unchanged() {
+    let secret: Fixed<[u8; 8]> = Fixed::new([0u8; 8]);
+    assert_eq!(secret.len(), 8);
+    assert_eq!(secret.byte_len(), 8);
+}


### PR DESCRIPTION
## Summary

Five small, confirmed defects to land before the next stable promotion. None block the current 0.9.0-rc.

**Metadata / docs (items 1–4):**
- Drop `"no-std"` from `secure-gate-compat/Cargo.toml` keywords — crates.io rejects more than 5 (was 6).
- Correct `release/0.8` MSRV documentation: `1.75` → `1.70` in `secure-gate-core/README.md` and `secure-gate-core/ROADMAP.md` (two occurrences each).
- Narrow `#![forbid(unsafe_code)]` claim in `secure-gate-core/SECURITY.md` from "enforced unconditionally" / "at crate level" to "in the library crate". The `src/bin/asm_check.rs` binary uses `#[unsafe(no_mangle)]` (Rust 2024 syntax) and is its own crate root — the library promise is intact, but the prior wording was imprecise.

**Breaking, pre-1.0 (item 5):**
- `RevealSecret::len()` previously returned `n_elements * size_of::<T>()` (bytes), violating Rust's universal `len()` = element-count contract (`Vec::len`, `slice::len`, etc.). Now returns element count for both `Dynamic<Vec<T>>` (`inner.len()`) and `Fixed<[T;N]>` (`N`).
- New provided method `RevealSecret::byte_len()` returns the byte size; overridden by both impls for multi-byte element types.
- **Behavior unchanged** for the common cases `Dynamic<Vec<u8>>`, `Dynamic<String>`, and `Fixed<[u8; N]>`.
- Four regression tests added in `tests/core_tests.rs`.

The same `len()` fix has been backported to `release/0.8` and merged separately (#130).

Pre-existing failure noted but not addressed: `tests/compile_fail_tests.rs::fixed_alias_zero_size_compile_fail` fails on `main` independent of these changes (verified by stashing).

## Test plan

- [x] `cargo test -p secure-gate --features alloc,cloneable,ct-eq,rand,std --test core_tests` — 41 passed (4 new)
- [ ] CI green
- [ ] `cargo package -p secure-gate-compat --list` succeeds (keyword count ≤ 5)
- [ ] No new clippy / lint warnings

https://claude.ai/code/session_01TXpMzKp8HM7tYXB9AGCADJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXpMzKp8HM7tYXB9AGCADJ)_