### PR TITLE
test: regenerate trybuild .stderr files for current rustc

### DIFF
--- a/secure-gate-core/tests/compile-fail/fixed_alias_zero_size.stderr
+++ b/secure-gate-core/tests/compile-fail/fixed_alias_zero_size.stderr
@@ -1,7 +1,7 @@
-error[E0080]: evaluation of constant value failed
+error[E0080]: index out of bounds: the length is 0 but the index is 0
  --> tests/compile-fail/fixed_alias_zero_size.rs:3:1
   |
 3 | fixed_alias!(ZeroKey, 0);
-  | ^^^^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the length is 0 but the index is 0
+  | ^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
   |
   = note: this error originates in the macro `fixed_alias` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/secure-gate-core/tests/compile-fail/serializable_secret_misuse.stderr
+++ b/secure-gate-core/tests/compile-fail/serializable_secret_misuse.stderr
@@ -2,11 +2,20 @@ error[E0277]: the trait bound `BadSecret: SerializableSecret` is not satisfied
   --> tests/compile-fail/serializable_secret_misuse.rs:11:35
    |
 11 |     let _ = serde_json::to_string(&Dynamic::<BadSecret>::new(BadSecret(vec![])));
-   |             --------------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SerializableSecret` is not implemented for `BadSecret`
+   |             --------------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `Serialize` is implemented for `Dynamic<T>`
+help: the trait `SerializableSecret` is not implemented for `BadSecret`
+  --> tests/compile-fail/serializable_secret_misuse.rs:7:1
+   |
+ 7 | struct BadSecret(Vec<u8>);
+   | ^^^^^^^^^^^^^^^^
+help: the trait `Serialize` is implemented for `Dynamic<T>`
+  --> src/dynamic.rs
+   |
+   | impl<T: zeroize::Zeroize + crate::SerializableSecret> serde::Serialize for Dynamic<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: required for `Dynamic<BadSecret>` to implement `Serialize`
 note: required by a bound in `serde_json::to_string`
   --> $CARGO/serde_json-$VERSION/src/ser.rs
@@ -25,7 +34,11 @@ error[E0277]: the trait bound `[u8; 32]: SerializableSecret` is not satisfied
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `Serialize` is implemented for `Fixed<T>`
+help: the trait `Serialize` is implemented for `Fixed<T>`
+  --> src/fixed.rs
+   |
+   | impl<T: zeroize::Zeroize + crate::SerializableSecret> serde::Serialize for Fixed<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: required for `Fixed<[u8; 32]>` to implement `Serialize`
 note: required by a bound in `serde_json::to_string`
   --> $CARGO/serde_json-$VERSION/src/ser.rs


### PR DESCRIPTION
## Summary

Two compile-fail tests' `.stderr` fixtures fell out of sync with the current rustc diagnostic format. **The tests still correctly reject the bad code** — only the textual rendering changed. With the prior fixtures, `cargo test -p secure-gate --test compile_fail_tests` failed even on a clean checkout of `main` (verified pre-existing during the #131 branch work).

**Diagnostic changes (rustc reformat, no behavior change):**

- `fixed_alias_zero_size` (E0080): the `evaluation of constant value failed` header now reads `index out of bounds: the length is 0 but the index is 0`, and the secondary-span text became `evaluation of \`_\` failed here`.
- `serializable_secret_misuse` (E0277): the `= help: the trait ... is not implemented` notes were converted to structured `help: ... --> path` blocks that point to the impl source location.

Regenerated via `TRYBUILD=overwrite cargo test -p secure-gate --features alloc,serde-serialize,encoding-hex --test compile_fail_tests` per the procedure documented at the top of `tests/compile_fail_tests.rs`.

## Test plan

- [x] `cargo test -p secure-gate --features alloc,serde-serialize,encoding-hex --test compile_fail_tests` — 3 passed
- [ ] CI green

https://claude.ai/code/session_01TXpMzKp8HM7tYXB9AGCADJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXpMzKp8HM7tYXB9AGCADJ)_