### PR TITLE
Clarify alias macros are type aliases, not newtypes

### DIFF
--- a/secure-gate-core/README.md
+++ b/secure-gate-core/README.md
@@ -102,7 +102,7 @@ assert_eq!(format!("{:?}", owned), "[REDACTED]");
 
 ### Macros for typed aliases
 
-`fixed_alias!`, `dynamic_alias!`, `fixed_generic_alias!`, and `dynamic_generic_alias!` create typed newtype wrappers with full visibility control, optional doc strings, and compile-time zero-size guards:
+`fixed_alias!`, `dynamic_alias!`, `fixed_generic_alias!`, and `dynamic_generic_alias!` create named type aliases over `Fixed<T>` / `Dynamic<T>` with full visibility control, optional doc strings, and (for `fixed_alias!`) a compile-time zero-size guard. They expand to plain `pub type` aliases, **not** newtypes — two aliases over the same underlying type are the same nominal type and assignable to each other. Use them for readability and audit grep targets, not for nominal separation between cryptographic roles:
 
 ```rust
 use secure_gate::{fixed_alias, dynamic_alias};
@@ -135,7 +135,7 @@ fn log_length<S: RevealSecret>(secret: &S) {
 
 - **Zero-cost safety** — mandatory zeroization on drop; `no_std` / `no_alloc` support.
 - **Audit-first API** — secrets cannot leak via `Deref`. Access requires explicit `with_secret` scopes or an auditable `expose_secret` escape hatch.
-- **Type-safe wrappers** — macros create newtype aliases that redact `Debug` output automatically.
+- **Named aliases** — macros create `type` aliases over `Fixed` / `Dynamic` that inherit redacted `Debug` and zeroize-on-drop. These are plain type aliases, not newtypes: same-shape aliases (e.g. two `Fixed<[u8; 32]>` aliases) are interchangeable at the type level — wrap in a `struct` newtype yourself if you need nominal separation.
 - **Batteries included** — optional, zero-overhead support for serde, constant-time comparison (`subtle`), and secure encoding (hex, base64url, bech32/m).
 - **No unsafe code** — enforced with `#![forbid(unsafe_code)]`.
 

--- a/secure-gate-core/src/macros/mod.rs
+++ b/secure-gate-core/src/macros/mod.rs
@@ -1,8 +1,15 @@
-//! Convenience macros for creating typed aliases to secure secret wrappers.
+//! Convenience macros for creating named aliases to secure secret wrappers.
 //!
-//! These macros create domain-specific newtype aliases (e.g., `Aes256Key`, `Password`)
+//! These macros create domain-specific type aliases (e.g., `Aes256Key`, `Password`)
 //! that inherit all security guarantees from [`Fixed`](crate::Fixed) or
 //! [`Dynamic`](crate::Dynamic): zeroize on drop, redacted `Debug`, explicit access only.
+//!
+//! These are plain Rust `type` aliases, **not** newtypes. Two aliases over the same
+//! underlying type (e.g. two `fixed_alias!` invocations with the same `N`) resolve to
+//! the same nominal type and are freely assignable to each other. The aliases improve
+//! readability and audit grep targets; they do not provide compile-time separation
+//! between distinct cryptographic roles. If you need nominal separation, wrap the alias
+//! in a `struct` newtype yourself.
 //!
 //! | Macro                   | Generates                   | Feature   |
 //! |-------------------------|-----------------------------|-----------|


### PR DESCRIPTION
The fixed_alias!, fixed_generic_alias!, dynamic_alias!, and
dynamic_generic_alias! macros expand to plain `pub type` aliases over
Fixed<T> / Dynamic<T>. Two aliases with the same underlying type are
the same nominal type, so the macros do not provide compile-time
separation between cryptographic roles. The previous wording ("newtype
aliases", "typed newtype wrappers", "Type-safe wrappers") could be read
as a nominal-separation claim, which downstream users have relied on.

Reword the three user-facing locations (src/macros/mod.rs, README
macros section, README "What You Get" bullet) to describe them as
named type aliases and call out the lack of nominal separation
explicitly. No behavior change.

https://claude.ai/code/session_01KbWBsd8H3PnxirLyXQD5Ea