### PR TITLE
docs: clarify realloc residue mitigations

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ use secure_gate::{dynamic_alias, fixed_alias, RevealSecret, RevealSecretMut};
 dynamic_alias!(pub Password, String);  // Dynamic<String>
 fixed_alias!(pub Aes256Key, 32);       // Fixed<[u8; 32]>
 
-let mut pw: Password = "hunter2".into();
-let key: Aes256Key = Aes256Key::new([42u8; 32]);
+let pw: Password = "hunter2".into();
+let mut key: Aes256Key = Aes256Key::new([42u8; 32]);
 
 // Scoped access — the borrow cannot outlive the closure
 pw.with_secret(|s| println!("length: {}", s.len()));
 
 // Mutable scoped access
-pw.with_secret_mut(|s: &mut String| s.push('!'));
+key.with_secret_mut(|bytes| bytes[0] = 0);
 
 // Direct reference — auditable escape hatch (FFI, third-party APIs)
-assert_eq!(pw.expose_secret(), "hunter2!");
+assert_eq!(pw.expose_secret(), "hunter2");
 ```
 
 All types print `[REDACTED]` in `Debug` output and zeroize their memory on drop.
@@ -55,6 +55,10 @@ All types print `[REDACTED]` in `Debug` output and zeroize their memory on drop.
 - **Timing-safe comparison** — `.ct_eq()` via the `ct-eq` feature (uses `subtle`)
 - **Opt-in risk** — cloning and serialization require explicit marker traits (`CloneableSecret`, `SerializableSecret`)
 - **Verified** — semantic drop-order tests, physical heap-byte verification via `ProxyAllocator`, AddressSanitizer in CI, Miri on nightly
+
+For `Dynamic<Vec<_>>` and `Dynamic<String>`, avoid capacity-changing mutations
+after wrapping unless your deployment handles allocator-level residue. See
+[`secure-gate-core/SECURITY.md`](secure-gate-core/SECURITY.md) for details.
 
 ## Workspace Layout
 

--- a/secure-gate-core/CHANGELOG.md
+++ b/secure-gate-core/CHANGELOG.md
@@ -26,7 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guidance: pre-allocate to max needed size, prefer `Fixed<[u8; N]>` for
   known-size secrets, or replace the wrapper rather than mutate in place.
   This is a fundamental limitation of standard-library collections shared
-  across the ecosystem; `Fixed<T>` is exempt.
+  across the ecosystem; `Fixed<T>` is exempt. The docs also point stricter
+  deployments at process / OS-level mitigations such as zero-on-dealloc global
+  allocators, Linux `init_on_free=1`, disabling core dumps, and encrypted swap.
 - **Finding 3 — `deserialize_with_limit` zeroization-scope misclaim (MEDIUM,
   docs-only).** The rustdoc on `Dynamic::<Vec<u8>>::deserialize_with_limit` and
   `Dynamic::<String>::deserialize_with_limit` previously suggested the

--- a/secure-gate-core/CHANGELOG.md
+++ b/secure-gate-core/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   across the ecosystem; `Fixed<T>` is exempt. The docs also point stricter
   deployments at process / OS-level mitigations such as zero-on-dealloc global
   allocators, Linux `init_on_free=1`, disabling core dumps, and encrypted swap.
+  `Dynamic::into_inner` rustdoc now also notes that capacity-changing mutations
+  after ownership transfer have the same realloc-residue caveat.
 - **Finding 3 — `deserialize_with_limit` zeroization-scope misclaim (MEDIUM,
   docs-only).** The rustdoc on `Dynamic::<Vec<u8>>::deserialize_with_limit` and
   `Dynamic::<String>::deserialize_with_limit` previously suggested the

--- a/secure-gate-core/README.md
+++ b/secure-gate-core/README.md
@@ -21,16 +21,17 @@ dynamic_alias!(pub Password, String);    // Dynamic<String>
 fixed_alias!(pub Aes256Key, 32);         // Fixed<[u8; 32]>
 
 let mut pw: Password = "hunter2".into();
-let key: Aes256Key = Aes256Key::new([42u8; 32]);
+let mut key: Aes256Key = Aes256Key::new([42u8; 32]);
 
 // Scoped access — preferred; the borrow cannot outlive the closure
 pw.with_secret(|s| println!("length: {}", s.len()));
 
-// Mutable scoped access
-pw.with_secret_mut(|s: &mut String| s.push('!'));
+// Mutable scoped access. For Dynamic<String> / Dynamic<Vec<u8>>, prefer
+// capacity-stable mutations or pre-allocate before wrapping; see SECURITY.md.
+key.with_secret_mut(|bytes| bytes[0] = 0);
 
 // Direct reference — auditable escape hatch (e.g. FFI, third-party APIs)
-assert_eq!(pw.expose_secret(), "hunter2!");
+assert_eq!(pw.expose_secret(), "hunter2");
 pw.expose_secret_mut().clear();
 
 #[cfg(all(feature = "encoding-hex", feature = "encoding-bech32"))]
@@ -265,6 +266,10 @@ See [`SerializableSecret`] in the [API docs](https://docs.rs/secure-gate) for th
 - **Zeroize on drop** — always active; inner type must implement `Zeroize`
 - **Timing-safe equality** — `ct-eq` feature (`.ct_eq()`) routes through `expose_secret()`, honoring the explicit-access model
 - **No unsafe code** — enforced with `#![forbid(unsafe_code)]`
+
+For `Dynamic<Vec<_>>` and `Dynamic<String>`, avoid capacity-changing mutations
+after wrapping unless your deployment handles allocator-level residue. See
+`SECURITY.md` for the realloc threat-model note and operational mitigations.
 
 Read [SECURITY.md](https://github.com/Slurp9187/secure-gate/blob/main/secure-gate-core/SECURITY.md) for the full threat model and mitigations.
 

--- a/secure-gate-core/SECURITY.md
+++ b/secure-gate-core/SECURITY.md
@@ -186,6 +186,15 @@ All secret access follows this explicit hierarchy (the table below expands on th
   workaround exists but trades off significant complexity and is not enabled
   by default in this crate. **`Fixed<T>` is exempt** — it has no realloc surface.
 
+  For stricter deployment threat models, handle this below the library layer:
+  install a zero-on-dealloc global allocator such as `zeroizing-alloc` in the
+  final binary, use OS or allocator zero-on-free facilities where available
+  (for example Linux `init_on_free=1` or hardened allocators), disable core
+  dumps for secret-holding processes, and ensure swap / hibernation storage is
+  encrypted. These are process-wide operational choices, so `secure-gate` treats
+  allocator-level zeroization as deployment configuration rather than a crate
+  feature.
+
 **Mitigations**
 
 - **For accessing secrets:** prefer the scoped `with_secret()` / `with_secret_mut()` closures

--- a/secure-gate-core/src/dynamic.rs
+++ b/secure-gate-core/src/dynamic.rs
@@ -100,7 +100,7 @@ use crate::traits::encoding::bech32m::ToBech32m;
 use crate::traits::encoding::hex::ToHex;
 
 #[cfg(feature = "rand")]
-use rand::{TryCryptoRng, TryRng, rngs::SysRng};
+use rand::{rngs::SysRng, TryCryptoRng, TryRng};
 
 // Dynamic<Vec<u8>> is always alloc-dependent, so the alloc-gated blanket traits
 // are always available when encoding features are enabled for this type.

--- a/secure-gate-core/src/dynamic.rs
+++ b/secure-gate-core/src/dynamic.rs
@@ -476,6 +476,10 @@ impl crate::RevealSecret for Dynamic<String> {
     /// confidentiality is preserved. This is the same OOM-safety pattern used by
     /// `from_protected_bytes` and `deserialize_with_limit`.
     ///
+    /// After ownership transfer, capacity-changing mutations on the returned
+    /// `InnerSecret<String>` have the same realloc-residue caveats as mutating
+    /// `Dynamic<String>` in place; see `SECURITY.md`.
+    ///
     /// See [`RevealSecret::into_inner`] for full documentation including the
     /// redacted `Debug` behavior.
     #[inline(always)]
@@ -526,6 +530,10 @@ impl<T: zeroize::Zeroize> crate::RevealSecret for Dynamic<Vec<T>> {
     /// unchanged and `Dynamic::drop` zeroizes the real secret during unwind —
     /// confidentiality is preserved. This is the same OOM-safety pattern used by
     /// `from_protected_bytes` and `deserialize_with_limit`.
+    ///
+    /// After ownership transfer, capacity-changing mutations on the returned
+    /// `InnerSecret<Vec<T>>` have the same realloc-residue caveats as mutating
+    /// `Dynamic<Vec<T>>` in place; see `SECURITY.md`.
     ///
     /// See [`RevealSecret::into_inner`] for full documentation including the
     /// redacted `Debug` behavior.

--- a/secure-gate-core/src/dynamic.rs
+++ b/secure-gate-core/src/dynamic.rs
@@ -44,11 +44,12 @@
 //! let len = pw.with_secret(|s: &String| s.len());
 //! assert_eq!(len, 7);
 //!
-//! // Tier 1 mutable — scoped mutation.
-//! pw.with_secret_mut(|s: &mut String| s.push('!'));
+//! // Tier 1 mutable — scoped mutation. Prefer capacity-stable mutations for
+//! // Dynamic<String> / Dynamic<Vec<u8>>; see SECURITY.md for realloc notes.
+//! pw.with_secret_mut(|s: &mut String| s.make_ascii_uppercase());
 //!
 //! // Tier 2 — direct reference (escape hatch).
-//! assert_eq!(pw.expose_secret(), "hunter2!");
+//! assert_eq!(pw.expose_secret(), "HUNTER2");
 //!
 //! // Tier 3 — owned consumption.
 //! let owned = pw.into_inner();
@@ -61,6 +62,12 @@
 //! Ensure your profile sets `panic = "unwind"` — `panic = "abort"` skips destructors
 //! and therefore skips zeroization. (`Dynamic` cannot be `static` since it requires
 //! `Box` allocation, so the static-secret warning from `Fixed` does not apply.)
+//!
+//! For `Dynamic<Vec<_>>` and `Dynamic<String>`, capacity-changing mutations can
+//! cause the standard allocator to free the previous buffer without zeroizing it.
+//! Pre-allocate to the maximum size, use capacity-stable mutations, or prefer
+//! [`Fixed<T>`](crate::Fixed) for known-size secrets. See `SECURITY.md` for the
+//! full threat-model discussion and deployment-level mitigations.
 //!
 //! # See also
 //!

--- a/secure-gate-core/src/traits/reveal_secret_mut.rs
+++ b/secure-gate-core/src/traits/reveal_secret_mut.rs
@@ -99,14 +99,11 @@ pub trait RevealSecretMut: RevealSecret {
     /// # Examples
     ///
     /// ```rust
-    /// # #[cfg(feature = "alloc")]
-    /// # {
-    /// use secure_gate::{Dynamic, RevealSecret, RevealSecretMut};
+    /// use secure_gate::{Fixed, RevealSecret, RevealSecretMut};
     ///
-    /// let mut pw: Dynamic<String> = Dynamic::new(String::from("hunter2"));
-    /// pw.expose_secret_mut().push('!');
-    /// assert_eq!(pw.expose_secret(), "hunter2!");
-    /// # }
+    /// let mut secret = Fixed::new([0u8; 4]);
+    /// secret.expose_secret_mut()[0] = 42;
+    /// assert_eq!(secret.expose_secret()[0], 42);
     /// ```
     fn expose_secret_mut(&mut self) -> &mut Self::Inner;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add deployment-level mitigations for `Dynamic<Vec<_>>` / `Dynamic<String>` realloc residue to `SECURITY.md` and the changelog.
- Align README and rustdoc examples so they do not demonstrate unreserved `Dynamic<String>` growth.
- Add brief public docs pointers to the realloc threat-model note.
- Note in `Dynamic::into_inner` rustdoc that capacity-changing mutations after ownership transfer have the same realloc-residue caveat.

## Testing
- `rustfmt --check secure-gate-core/src/dynamic.rs secure-gate-core/src/traits/reveal_secret_mut.rs`
- `cargo test -p secure-gate --doc`
- `cargo test -p secure-gate --lib`
- Follow-up: `rustfmt --check secure-gate-core/src/dynamic.rs`
- Follow-up: `cargo test -p secure-gate --doc`

Note: full `cargo fmt --check` currently reports pre-existing formatting drift in unrelated `secure-gate-compat/tests/*` files; the touched Rust files pass targeted rustfmt.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fa7042a-d969-4692-ba75-cc72a353a15b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fa7042a-d969-4692-ba75-cc72a353a15b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

