### PR TITLE
docs: consolidate inherent Rust memory-residue limitations + add #[must_use]

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ For `Dynamic<Vec<_>>` and `Dynamic<String>`, avoid capacity-changing mutations
 after wrapping unless your deployment handles allocator-level residue. See
 [`secure-gate-core/SECURITY.md`](secure-gate-core/SECURITY.md) for details.
 
+### Known limitations
+
+Three universal in-memory-secret limits apply (same in C, C++, Go, and Rust):
+
+- **Stack-move residue** — moving a `Fixed<T>` leaves bytes in the prior stack slot. Use `Fixed::new_with`, pass by reference, or use `Dynamic<T>` for long-lived secrets.
+- **Heap-reallocation residue** — `Vec`/`String` realloc frees old buffers unzeroed. Pre-size, use `Dynamic<[u8; N]>` (boxed array), or install [`zeroizing-alloc`](https://crates.io/crates/zeroizing-alloc) as the global allocator.
+- **Swap / core dumps** — OS-level concerns; use `mlock`, encrypted swap, and disabled core dumps for sensitive processes.
+
+Full discussion: [`SECURITY.md` § Inherent Rust Limitations](secure-gate-core/SECURITY.md#inherent-rust-limitations).
+
 ## Workspace Layout
 
 ```

--- a/secure-gate-core/README.md
+++ b/secure-gate-core/README.md
@@ -268,10 +268,22 @@ See [`SerializableSecret`] in the [API docs](https://docs.rs/secure-gate) for th
 - **No unsafe code** — enforced with `#![forbid(unsafe_code)]`
 
 For `Dynamic<Vec<_>>` and `Dynamic<String>`, avoid capacity-changing mutations
-after wrapping unless your deployment handles allocator-level residue. See
-`SECURITY.md` for the realloc threat-model note and operational mitigations.
+after wrapping unless your deployment handles allocator-level residue. For
+known-size heap-only key material, prefer `Dynamic<[u8; N]>` (boxed array — no
+realloc surface). See `SECURITY.md` for the realloc threat-model note and
+operational mitigations.
 
-Read [SECURITY.md](https://github.com/Slurp9187/secure-gate/blob/main/secure-gate-core/SECURITY.md) for the full threat model and mitigations.
+### Inherent Rust limitations
+
+Three universal in-memory-secret limits apply (same across C, C++, Go, and
+Rust): **stack-move residue** (mitigated by `Fixed::new_with`, pass-by-reference,
+or switching to `Dynamic<T>`), **heap-reallocation residue** (mitigated by
+pre-sizing, `Dynamic<[u8; N]>`, or the
+[`zeroizing-alloc`](https://crates.io/crates/zeroizing-alloc) global allocator),
+and **swap / core dumps** (OS-level — `mlock`, encrypted swap, disabled core
+dumps).
+
+Read [SECURITY.md](https://github.com/Slurp9187/secure-gate/blob/main/secure-gate-core/SECURITY.md) for the full threat model and mitigations, including the dedicated [§ Inherent Rust Limitations](https://github.com/Slurp9187/secure-gate/blob/main/secure-gate-core/SECURITY.md#inherent-rust-limitations) section.
 
 ## Audit Surface (Secret Materialization)
 

--- a/secure-gate-core/SECURITY.md
+++ b/secure-gate-core/SECURITY.md
@@ -24,6 +24,71 @@ This document outlines the security model, design choices, strengths, limitation
 - **Allocation-based DoS from deserialization** — `MAX_DESERIALIZE_BYTES` is a post-materialization bound only; the upstream deserializer may allocate arbitrarily first.
 - **Stack/register residue** — temporaries, FFI boundaries, and compiler spills are outside wrapper control.
 
+## Inherent Rust Limitations
+
+These three limitations are inherent to systems languages with a stack, a
+growable heap, and an OS that pages memory. They are **not unique to
+`secure-gate`** — `secrecy`, `zeroize`-wrapped collections, C/C++ secret
+crates, and Go's `memguard` all share the same threat model. The crate
+documents them honestly rather than overclaiming.
+
+### 1. Stack-move residue (`Fixed<T>`)
+
+When a `Fixed<T>` is moved (returned, passed by value, stored into a
+struct field), the bytes are bitwise-copied to the new location and the
+**original stack slot retains the original bits** until a later stack
+frame overwrites them. `ZeroizeOnDrop` only fires on the *current*
+location. The Rust language has no facility to direct the compiler to
+zero an out-of-scope stack slot.
+
+**Recommended patterns:**
+
+- Use [`Fixed::new_with`](https://docs.rs/secure-gate/latest/secure_gate/struct.Fixed.html#method.new_with) instead of [`Fixed::new`](https://docs.rs/secure-gate/latest/secure_gate/struct.Fixed.html#method.new) to write secret material directly into the wrapper's storage — eliminates the construction-site stack temporary.
+- Pass `&Fixed<T>` / `&mut Fixed<T>` by reference rather than `Fixed<T>` by value. Keep the wrapper short-scope.
+- For long-lived secrets, prefer [`Dynamic<T>`](https://docs.rs/secure-gate/latest/secure_gate/struct.Dynamic.html) — heap-only, no stack surface to leak from.
+- For address-stability needs (FFI, self-referential structs), users may pin the wrapper at the call site: `let key = core::pin::pin!(Fixed::new_with(|a| …));`. This is opt-in; the crate does not impose pinning by default because it would break idiomatic use (returning, storing).
+
+### 2. Heap-reallocation residue (`Dynamic<Vec<T>>` / `Dynamic<String>`)
+
+When a `Vec<T>` or `String` grows past its current capacity, the
+standard library allocates a new buffer, memcpys the contents, and frees
+the old buffer **without zeroing**. `ZeroizingOnDrop` only zeros the
+*currently held* allocation. The freed bytes remain readable in heap
+memory until the allocator reuses or unmaps the page; they survive into
+core dumps and swap.
+
+**Recommended patterns:**
+
+- For **known-size key material**, prefer [`Fixed<[u8; N]>`](https://docs.rs/secure-gate/latest/secure_gate/struct.Fixed.html) (no allocation) or `Dynamic<[u8; N]>` (heap-only, fixed size — no realloc surface).
+- For **bounded-size variable-length secrets**, pre-size with `Vec::with_capacity(MAX)` / `String::with_capacity(MAX)` *before* wrapping in `Dynamic`, then only perform capacity-stable mutations through `with_secret_mut`.
+- For **infrequent updates**, replace the entire wrapper rather than mutating in place: `dyn_secret = Dynamic::new_with(|v| …)` — the old `Dynamic` zeroizes its buffer on drop.
+- For **deployment-level remediation**, install a zero-on-deallocate global allocator such as [`zeroizing-alloc`](https://crates.io/crates/zeroizing-alloc) in the final binary, or rely on OS facilities (Linux `init_on_free=1`, hardened allocators). These are process-wide operational choices rather than a per-crate feature.
+
+A custom-allocator-parameterized `Dynamic<T, A>` (analogous to C++'s
+`std::vector<T, ZeroingAllocator<T>>`) would resolve this at the type
+level but currently requires nightly Rust (`allocator_api`) and `unsafe`
+code. `secure-gate` does not enable it; users with strict realloc-residue
+requirements should adopt the global-allocator approach above.
+
+### 3. Swap / core dumps / external memory exposure
+
+Process memory may be paged to disk (swap, hibernation) or written to a
+core dump on crash. Once written, zeroization-on-drop in the running
+process is irrelevant — the bytes already left the process's address
+space. This applies identically to C, C++, Go, and Rust; it is OS-level
+and outside any in-process library's reach.
+
+**Recommended patterns (deployment-level):**
+
+- Use **encrypted swap** (default on most modern Linux distributions, FileVault on macOS, BitLocker on Windows).
+- Disable core dumps for secret-holding processes: `prctl(PR_SET_DUMPABLE, 0)` on Linux, `setrlimit(RLIMIT_CORE, 0)` for the whole process, or container `--ulimit core=0`.
+- `mlock` / `mlockall` to prevent specific allocations from being paged out — at the cost of pinning physical memory and consuming the process's lock budget.
+- Disable hibernation on machines that hold long-lived keys, or ensure hibernation storage is encrypted.
+
+`secure-gate` treats all three of these mitigations as deployment
+configuration. The crate does not call `mlock` or set process flags
+itself.
+
 ## Audit Status
 
 `secure-gate` has **not** undergone an independent security audit.
@@ -187,13 +252,16 @@ All secret access follows this explicit hierarchy (the table below expands on th
   by default in this crate. **`Fixed<T>` is exempt** — it has no realloc surface.
 
   For stricter deployment threat models, handle this below the library layer:
-  install a zero-on-dealloc global allocator such as `zeroizing-alloc` in the
-  final binary, use OS or allocator zero-on-free facilities where available
+  install a zero-on-dealloc global allocator such as
+  [`zeroizing-alloc`](https://crates.io/crates/zeroizing-alloc) in the final
+  binary (the recommended approach when downstream code controls the global
+  allocator), use OS or allocator zero-on-free facilities where available
   (for example Linux `init_on_free=1` or hardened allocators), disable core
   dumps for secret-holding processes, and ensure swap / hibernation storage is
   encrypted. These are process-wide operational choices, so `secure-gate` treats
   allocator-level zeroization as deployment configuration rather than a crate
-  feature.
+  feature. See the "Inherent Rust Limitations" section above for the broader
+  context.
 
 **Mitigations**
 

--- a/secure-gate-core/src/dynamic.rs
+++ b/secure-gate-core/src/dynamic.rs
@@ -192,7 +192,6 @@ impl<T: ?Sized + zeroize::Zeroize> Dynamic<T> {
     /// Requires the `alloc` feature (which `Dynamic<T>` itself always requires).
     #[doc(alias = "from")]
     #[inline(always)]
-    #[must_use]
     pub fn new<U>(value: U) -> Self
     where
         U: Into<Box<T>>,
@@ -426,7 +425,6 @@ impl Dynamic<Vec<u8>> {
     /// zeroed during stack unwinding if `f` panics. Constructed via the same
     /// `Zeroizing` + swap pattern used by `from_protected_bytes`.
     #[inline(always)]
-    #[must_use]
     pub fn new_with<F>(f: F) -> Self
     where
         F: FnOnce(&mut alloc::vec::Vec<u8>),
@@ -458,7 +456,6 @@ impl Dynamic<alloc::string::String> {
     /// zeroed during stack unwinding if `f` panics. Constructed via the same
     /// `Zeroizing` + swap pattern used by `from_protected_bytes`.
     #[inline(always)]
-    #[must_use]
     pub fn new_with<F>(f: F) -> Self
     where
         F: FnOnce(&mut alloc::string::String),
@@ -639,7 +636,6 @@ impl Dynamic<alloc::vec::Vec<u8>> {
     /// # }
     /// ```
     #[inline]
-    #[must_use]
     pub fn from_random(len: usize) -> Self {
         Self::new_with(|v| {
             v.resize(len, 0u8);

--- a/secure-gate-core/src/dynamic.rs
+++ b/secure-gate-core/src/dynamic.rs
@@ -20,6 +20,21 @@
 //! - **Panic safety** — all decode constructors use the `from_protected_bytes` pattern:
 //!   a `Zeroizing` wrapper survives OOM panics from `Box::new`.
 //!
+//! # Choosing the inner type for security
+//!
+//! Different inner types have different reallocation-residue profiles:
+//!
+//! | Inner type | Realloc surface | Use case |
+//! |---|---|---|
+//! | `Dynamic<[u8; N]>` (boxed array) | **None** — fixed size | Long-lived known-size keys held on the heap |
+//! | `Dynamic<Vec<u8>>` pre-sized | None *if* you avoid capacity-growing mutations | Variable-length secrets with a known upper bound |
+//! | `Dynamic<Vec<u8>>` growable | **Yes** — each realloc leaves the old buffer unzeroed | Convenient, but see realloc-residue warning below |
+//! | `Dynamic<String>` | Same as `Dynamic<Vec<u8>>` | Passwords, API keys |
+//!
+//! For **long-lived, known-size key material**, prefer `Dynamic<[u8; N]>` —
+//! it combines `Dynamic`'s heap-only property with zero realloc surface.
+//! See `SECURITY.md` § "Inherent Rust Limitations" for the broader discussion.
+//!
 //! # Construction
 //!
 //! | Constructor | Notes |
@@ -65,9 +80,12 @@
 //!
 //! For `Dynamic<Vec<_>>` and `Dynamic<String>`, capacity-changing mutations can
 //! cause the standard allocator to free the previous buffer without zeroizing it.
-//! Pre-allocate to the maximum size, use capacity-stable mutations, or prefer
-//! [`Fixed<T>`](crate::Fixed) for known-size secrets. See `SECURITY.md` for the
-//! full threat-model discussion and deployment-level mitigations.
+//! Pre-allocate to the maximum size, use capacity-stable mutations, prefer
+//! `Dynamic<[u8; N]>` (no realloc surface) for known-size heap secrets, or use
+//! [`Fixed<T>`](crate::Fixed) for known-size stack secrets. See `SECURITY.md` for
+//! the full threat-model discussion and deployment-level mitigations including
+//! the [`zeroizing-alloc`](https://crates.io/crates/zeroizing-alloc) global
+//! allocator.
 //!
 //! # See also
 //!
@@ -157,6 +175,7 @@ use crate::traits::decoding::hex::FromHexStr;
 ///
 /// - [`RevealSecret`](crate::RevealSecret) / [`RevealSecretMut`](crate::RevealSecretMut) — the 3-tier access traits.
 /// - [`Fixed<T>`](crate::Fixed) — stack-allocated alternative.
+#[must_use = "Dynamic<T> holds secret material; dropping it on the floor usually indicates a bug — bind with `let _name = ...` or chain a method call"]
 pub struct Dynamic<T: ?Sized + zeroize::Zeroize> {
     inner: Box<T>,
 }
@@ -173,6 +192,7 @@ impl<T: ?Sized + zeroize::Zeroize> Dynamic<T> {
     /// Requires the `alloc` feature (which `Dynamic<T>` itself always requires).
     #[doc(alias = "from")]
     #[inline(always)]
+    #[must_use]
     pub fn new<U>(value: U) -> Self
     where
         U: Into<Box<T>>,
@@ -406,6 +426,7 @@ impl Dynamic<Vec<u8>> {
     /// zeroed during stack unwinding if `f` panics. Constructed via the same
     /// `Zeroizing` + swap pattern used by `from_protected_bytes`.
     #[inline(always)]
+    #[must_use]
     pub fn new_with<F>(f: F) -> Self
     where
         F: FnOnce(&mut alloc::vec::Vec<u8>),
@@ -437,6 +458,7 @@ impl Dynamic<alloc::string::String> {
     /// zeroed during stack unwinding if `f` panics. Constructed via the same
     /// `Zeroizing` + swap pattern used by `from_protected_bytes`.
     #[inline(always)]
+    #[must_use]
     pub fn new_with<F>(f: F) -> Self
     where
         F: FnOnce(&mut alloc::string::String),
@@ -617,6 +639,7 @@ impl Dynamic<alloc::vec::Vec<u8>> {
     /// # }
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_random(len: usize) -> Self {
         Self::new_with(|v| {
             v.resize(len, 0u8);

--- a/secure-gate-core/src/fixed.rs
+++ b/secure-gate-core/src/fixed.rs
@@ -206,7 +206,6 @@ impl<T: zeroize::Zeroize> Fixed<T> {
     /// assert_eq!(secret.len(), 32);
     /// ```
     #[inline(always)]
-    #[must_use]
     pub const fn new(value: T) -> Self {
         Fixed { inner: value }
     }
@@ -308,7 +307,6 @@ impl<const N: usize> Fixed<[u8; N]> {
     /// [`Dynamic<T>`](crate::Dynamic) over moving `Fixed<T>` around — each
     /// move-by-value leaves residue in the previous stack slot.
     #[inline(always)]
-    #[must_use]
     pub fn new_with<F>(f: F) -> Self
     where
         F: FnOnce(&mut [u8; N]),
@@ -851,7 +849,6 @@ impl<const N: usize> Fixed<[u8; N]> {
     /// # }
     /// ```
     #[inline]
-    #[must_use]
     pub fn from_random() -> Self {
         Self::new_with(|arr| {
             SysRng

--- a/secure-gate-core/src/fixed.rs
+++ b/secure-gate-core/src/fixed.rs
@@ -15,6 +15,12 @@
 //! - **Opt-in `Clone`** — requires `T: CloneableSecret` and the `cloneable` feature.
 //! - **Opt-in `Serialize`/`Deserialize`** — requires marker traits and the
 //!   `serde-serialize`/`serde-deserialize` features.
+//! - **Avoid move-by-value for long-lived secrets.** Each move of a `Fixed<T>`
+//!   bitwise-copies the bytes to a new location and leaves the original stack
+//!   slot uncleared until a later frame overwrites it. Pass `&Fixed<T>` /
+//!   `&mut Fixed<T>` by reference, keep the wrapper short-scope, or use
+//!   [`Dynamic<T>`](crate::Dynamic) for long-lived material (heap-only — no
+//!   stack residue surface). See `SECURITY.md` § "Inherent Rust Limitations".
 //!
 //! # Construction
 //!
@@ -175,6 +181,7 @@ fn drain_bech32_payload<const N: usize>(
 ///
 /// `const fn new` compiles in `static` position, but **must not** be used there
 /// because `Drop` does not run on statics, which means zeroization is skipped.
+#[must_use = "Fixed<T> holds secret material; dropping it on the floor usually indicates a bug — bind with `let _name = ...` or chain a method call"]
 pub struct Fixed<T: zeroize::Zeroize> {
     inner: T,
 }
@@ -199,6 +206,7 @@ impl<T: zeroize::Zeroize> Fixed<T> {
     /// assert_eq!(secret.len(), 32);
     /// ```
     #[inline(always)]
+    #[must_use]
     pub const fn new(value: T) -> Self {
         Fixed { inner: value }
     }
@@ -295,7 +303,12 @@ impl<const N: usize> Fixed<[u8; N]> {
     ///
     /// - [`Dynamic::new_with`](crate::Dynamic::new_with) — the heap-allocated
     ///   equivalent (requires `alloc`).
+    ///
+    /// If the secret will outlive the current function, prefer
+    /// [`Dynamic<T>`](crate::Dynamic) over moving `Fixed<T>` around — each
+    /// move-by-value leaves residue in the previous stack slot.
     #[inline(always)]
+    #[must_use]
     pub fn new_with<F>(f: F) -> Self
     where
         F: FnOnce(&mut [u8; N]),
@@ -838,6 +851,7 @@ impl<const N: usize> Fixed<[u8; N]> {
     /// # }
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_random() -> Self {
         Self::new_with(|arr| {
             SysRng

--- a/secure-gate-core/src/lib.rs
+++ b/secure-gate-core/src/lib.rs
@@ -185,6 +185,27 @@
 //! [SECURITY.md](https://github.com/Slurp9187/secure-gate/blob/main/secure-gate-core/SECURITY.md)
 //! for the full threat model.
 //!
+//! # Inherent Rust Limitations
+//!
+//! Three universal limits apply to any in-memory secret library in Rust (and in
+//! C, C++, and Go) — `secure-gate` documents them honestly rather than
+//! overclaiming:
+//!
+//! - **Stack-move residue**: moving a [`Fixed<T>`] by value leaves the prior stack
+//!   slot uncleared until a later frame overwrites it. Prefer
+//!   [`Fixed::new_with`](Fixed::new_with), pass by reference, or use
+//!   [`Dynamic<T>`] for long-lived secrets.
+//! - **Heap-reallocation residue**: `Vec` / `String` realloc frees the old buffer
+//!   unzeroed. Pre-size, use `Dynamic<[u8; N]>` (boxed array — no realloc surface),
+//!   or install a zero-on-dealloc global allocator such as `zeroizing-alloc` at
+//!   the binary level.
+//! - **Swap / core dumps**: process memory paged to disk or written on crash is
+//!   outside any in-process library's reach. Use OS facilities (`mlock`,
+//!   encrypted swap, disabled core dumps).
+//!
+//! Full discussion in
+//! [SECURITY.md § Inherent Rust Limitations](https://github.com/Slurp9187/secure-gate/blob/main/secure-gate-core/SECURITY.md#inherent-rust-limitations).
+//!
 //! See the [README](https://github.com/Slurp9187/secure-gate/blob/main/README.md) and
 //! [SECURITY.md](https://github.com/Slurp9187/secure-gate/blob/main/SECURITY.md) for full details.
 


### PR DESCRIPTION
## What

Re-applies a change that was stranded on the stale `claude/rust-memory-residue-shortfalls-FVXtt` branch (original commit `008bd78`, cut from a pre-`SentinelValue`-refactor `main`). Cherry-picked onto current `main` with `-X renormalize` so the pre-normalization CRLF/LF churn didn't leak into the diff.

## Changes

- **`#[must_use]` hardening** — added to the `Fixed<T>` and `Dynamic<T>` struct declarations and to their `Self`-returning constructors (`new`, `new_with`, `from_random`) with a tailored "you dropped a secret on the floor" message. `Result`-returning constructors are already covered by std's `#[must_use]` on `Result`.
- **Consolidated "Inherent Rust Limitations" docs** — groups the three universal memory-residue caveats (stack-move residue, heap-reallocation residue, swap/core dumps) into one anchored section in `SECURITY.md`, `lib.rs`, and both READMEs, plus positive guidance in the `Fixed`/`Dynamic` module docs (prefer `Fixed::new_with` / pass-by-reference / `Dynamic<[u8; N]>` / `zeroizing-alloc`).

## Not a behavior change

Docs + lint attributes only. The `SentinelValue` `into_inner` refactor already on `main` is preserved untouched.

## Verification

- `cargo build`/`test` under `--features full` **and** `--no-default-features`: all unit, integration, and doctests pass.
- Zero new warnings (no stray `unused_must_use` from internal code).
- Diff is `+158 / -10` across 6 files with no line-ending churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
